### PR TITLE
fix : 캐릭터 최종 성장 시 오류 수정

### DIFF
--- a/src/main/java/univ/earthbreaker/namu/core/domain/point/ProvideEnergyPointCommand.java
+++ b/src/main/java/univ/earthbreaker/namu/core/domain/point/ProvideEnergyPointCommand.java
@@ -6,15 +6,24 @@ import univ.earthbreaker.namu.core.domain.common.SelfValidating;
 
 public class ProvideEnergyPointCommand extends SelfValidating<ProvideEnergyPointCommand> {
 
+	private static final String NOT_ALLOWED_ENERGY_TYPE = "DEFAULT";
+
 	private final @NotNull Long memberNo;
 	private final @NotNull Integer point;
-	private final @NotBlank String energyType;
+	private final @NotNull @NotBlank String energyType;
 
 	public ProvideEnergyPointCommand(Long memberNo, Integer point, String energyType) {
+		this.validateEnergyType(energyType);
+		this.validateSelf("memberNo, point 는 null 이 될 수 없고, energyType 는 null 혹은 공백일 수 없습니다");
 		this.memberNo = memberNo;
 		this.point = point;
 		this.energyType = energyType;
-		this.validateSelf("memberNo, point 는 null 이 될 수 없고, energyType 는 공백일 수 없습니다");
+	}
+
+	private void validateEnergyType(String energyType) {
+		if (energyType.equals(NOT_ALLOWED_ENERGY_TYPE)) {
+			throw new IllegalArgumentException("캐릭터에게 제공할 에너지 타입은 DEFAULT 일 수 없습니다");
+		}
 	}
 
 	public Long getMemberNo() {

--- a/src/main/java/univ/earthbreaker/namu/core/domain/point/ProvideEnergyPointCommand.java
+++ b/src/main/java/univ/earthbreaker/namu/core/domain/point/ProvideEnergyPointCommand.java
@@ -13,11 +13,11 @@ public class ProvideEnergyPointCommand extends SelfValidating<ProvideEnergyPoint
 	private final @NotNull @NotBlank String energyType;
 
 	public ProvideEnergyPointCommand(Long memberNo, Integer point, String energyType) {
-		this.validateEnergyType(energyType);
-		this.validateSelf("memberNo, point 는 null 이 될 수 없고, energyType 는 null 혹은 공백일 수 없습니다");
 		this.memberNo = memberNo;
 		this.point = point;
 		this.energyType = energyType;
+		this.validateEnergyType(energyType);
+		this.validateSelf("memberNo, point 는 null 이 될 수 없고, energyType 는 null 혹은 공백일 수 없습니다");
 	}
 
 	private void validateEnergyType(String energyType) {

--- a/src/main/java/univ/earthbreaker/namu/database/core/character/CharacterJpaRepository.java
+++ b/src/main/java/univ/earthbreaker/namu/database/core/character/CharacterJpaRepository.java
@@ -17,12 +17,12 @@ public interface CharacterJpaRepository extends JpaRepository<CharacterJpaEntity
 
 	@Query(
 		value = """
-			SELECT c.* FROM character c
-			WHERE c.level = :level
-			    AND c.group_number = :groupNumber
-			    AND c.is_endangered = :isEndangered
-			    AND c.type = :type
+			SELECT nc.* FROM namu_character nc
+			WHERE nc.level = :level
+			    AND nc.group_number = :groupNumber
+			    AND nc.is_endangered = :isEndangered
+			    AND nc.type = :type
 			ORDER BY RAND() LIMIT 1""",
 		nativeQuery = true)
-	@Nullable CharacterJpaEntity findRandomBy(int level, int groupNumber, boolean isEndangered, CharacterType type);
+	@Nullable CharacterJpaEntity findRandomBy(int level, int groupNumber, boolean isEndangered, String type);
 }

--- a/src/main/java/univ/earthbreaker/namu/database/core/character/CharacterRepositoryAdapter.java
+++ b/src/main/java/univ/earthbreaker/namu/database/core/character/CharacterRepositoryAdapter.java
@@ -34,7 +34,7 @@ public class CharacterRepositoryAdapter implements CharacterRepository {
 			randomDbQuery.level(),
 			randomDbQuery.groupNumber(),
 			randomDbQuery.isEndangered(),
-			randomDbQuery.characterType()
+			randomDbQuery.characterType().name()
 		);
 		return getNamuCharacter(characterJpaEntity);
 	}

--- a/src/main/resources/static/docs/home-api.html
+++ b/src/main/resources/static/docs/home-api.html
@@ -490,9 +490,10 @@ Host: namu.api.docs</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 118
+Content-Length: 149
 
 {
+  "characterType" : "DEFAULT",
   "imageUrl" : "https://namu.test.image.com/character-dir/test_image.png",
   "requiredExp" : 3,
   "currentExp" : 0
@@ -516,6 +517,11 @@ Content-Length: 118
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>characterType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 캐릭터의 타입</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrl</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1024,9 +1024,10 @@ Host: namu.api.docs</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 118
+Content-Length: 149
 
 {
+  "characterType" : "DEFAULT",
   "imageUrl" : "https://namu.test.image.com/character-dir/test_image.png",
   "requiredExp" : 3,
   "currentExp" : 0
@@ -1050,6 +1051,11 @@ Content-Length: 118
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>characterType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 캐릭터의 타입</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrl</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>


### PR DESCRIPTION
## 수정 사항

database 의 캐릭터 테이블 명을 character 에서 namu_character 로 변경 했었는데요, 해당 부분에 대한 native query 를 사용하는 부분에서 수정을 제대로 해주지 않아 발생한 문제였습니다.

```java
@Query(
	value = """
		SELECT c.* FROM character c
		WHERE c.level = :level
		    AND c.group_number = :groupNumber
		    AND c.is_endangered = :isEndangered
		    AND c.type = :type
		ORDER BY RAND() LIMIT 1""",
	nativeQuery = true)
@Nullable CharacterJpaEntity findRandomBy(int level, int groupNumber, boolean isEndangered, CharacterType type);
```

따라서 다음과 같이 변경해주었습니다.

```java
@Query(
	value = """
		SELECT nc.* FROM namu_character nc
		WHERE nc.level = :level
		    AND nc.group_number = :groupNumber
	            AND nc.is_endangered = :isEndangered
		    AND nc.type = :type
		ORDER BY RAND() LIMIT 1""",
	nativeQuery = true)
@Nullable CharacterJpaEntity findRandomBy(int level, int groupNumber, boolean isEndangered, CharacterType type);
```

하지만 테스트 시, 다음과 같은 오류가 발생했는데요.

```
org.h2.jdbc.JdbcSQLDataException: Data conversion error converting "CHARACTER VARYING to DECFLOAT";
```
`nativeQuery=ture` 옵션으로 네이티브 쿼리를 생성하면, enum 타입을 varchar 형으로 바인딩 하지 못하고 tinyint 로 바인딩을 해서 발생한 오류인 것으로 보였습니다.
따라서 다음과 같이 수정했습니다.

```java
@Query(
	value = """
		SELECT nc.* FROM namu_character nc
		WHERE nc.level = :level
		    AND nc.group_number = :groupNumber
		    AND nc.is_endangered = :isEndangered
		    AND nc.type = :type
		ORDER BY RAND() LIMIT 1""",
	nativeQuery = true)
@Nullable CharacterJpaEntity findRandomBy(int level, int groupNumber, boolean isEndangered, String type);
```


### 관련 이슈
- #86 


