### PR TITLE
Refactor/issue/108 : 이미지 처리 작업을 임의의 외부 서버로 대체하기 

### DIFF
--- a/http/local/mission/mission-api.http
+++ b/http/local/mission/mission-api.http
@@ -27,3 +27,23 @@ PATCH /v1/missions/certification/fail/2
 Host: localhost:8080
 Content-Type: multipart/form-data; boundary=boundary
 Authorization: Bearer {{access_token}}
+
+
+
+### 미션 인증 성공 v2
+POST /v2/missions/certification/success/1 HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; boundary=boundary
+Authorization: Bearer {{access_token}}
+
+--boundary
+Content-Disposition: form-data; name="imageFile"; filename="test-image.png"
+Content-Type: image/png
+
+< ./test-image.png
+
+--boundary
+Content-Disposition: form-data; name="content"
+
+인증 성공한 사진과 함께 작성된 글
+--boundary

--- a/src/main/java/univ/earthbreaker/namu/core/api/config/WebConfig.java
+++ b/src/main/java/univ/earthbreaker/namu/core/api/config/WebConfig.java
@@ -41,7 +41,8 @@ public class WebConfig implements WebMvcConfigurer {
 			.excludePathPatterns("/v1/admin/**")
 			.excludePathPatterns(DOCUMENT_PATH)
 			.excludePathPatterns("/v1/auth/login/kakao")
-			.excludePathPatterns("/v1/auth/reissue");
+			.excludePathPatterns("/v1/auth/reissue")
+			.excludePathPatterns("/external/**");
 		registry.addInterceptor(traceLoggingInterceptor)
 			.addPathPatterns("/**")
 			.excludePathPatterns("/")

--- a/src/main/java/univ/earthbreaker/namu/core/api/mission/MemberMissionCertifyController.java
+++ b/src/main/java/univ/earthbreaker/namu/core/api/mission/MemberMissionCertifyController.java
@@ -31,7 +31,7 @@ public class MemberMissionCertifyController {
 
 	public MemberMissionCertifyController(
 		MemberMissionCertifyService memberMissionCertifyService,
-		ImageManager imageManager,
+		@Qualifier("awsS3ImageManager") ImageManager imageManager,
 		@Qualifier("missionPostImagePathGen") ImagePathKeyGenerator imagePathKeyGenerator
 	) {
 		this.memberMissionCertifyService = memberMissionCertifyService;

--- a/src/main/java/univ/earthbreaker/namu/core/api/mission/MissionCertifyController.java
+++ b/src/main/java/univ/earthbreaker/namu/core/api/mission/MissionCertifyController.java
@@ -1,0 +1,50 @@
+package univ.earthbreaker.namu.core.api.mission;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import univ.earthbreaker.namu.core.api.auth.support.AuthMapping;
+import univ.earthbreaker.namu.core.api.auth.support.LoginMember;
+import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.external.aws.image.ImageManager;
+import univ.earthbreaker.namu.external.aws.image.ImagePathKeyGenerator;
+import univ.earthbreaker.namu.external.aws.image.ImageUploadCommand;
+
+@RestController
+@RequestMapping("/v2/missions")
+public class MissionCertifyController {
+
+	private final ImageManager imageManager;
+	private final ImagePathKeyGenerator imagePathKeyGenerator;
+	private final MemberMissionCertifyService missionCertifyService;
+
+	public MissionCertifyController(
+		@Qualifier("externalImageManager") ImageManager imageManager,
+		@Qualifier("missionPostImagePathGen") ImagePathKeyGenerator imagePathKeyGenerator,
+		MemberMissionCertifyService missionCertifyService
+	) {
+		this.imageManager = imageManager;
+		this.imagePathKeyGenerator = imagePathKeyGenerator;
+		this.missionCertifyService = missionCertifyService;
+	}
+
+	@AuthMapping
+	@PostMapping(path = "/certification/success/{missionNo}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<String> success(
+		@LoginMember Long memberNo,
+		@PathVariable Long missionNo,
+		@RequestPart(value = "content") String content,
+		@RequestPart(value = "imageFile") MultipartFile missionImageFile
+	) {
+		String result = imageManager.upload(ImageUploadCommand.forMember(memberNo, missionImageFile, imagePathKeyGenerator));
+		return ResponseEntity.status(HttpStatus.CREATED).body(result);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/aws/image/AwsS3ImageEventHandler.java
+++ b/src/main/java/univ/earthbreaker/namu/external/aws/image/AwsS3ImageEventHandler.java
@@ -1,6 +1,7 @@
 package univ.earthbreaker.namu.external.aws.image;
 
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,7 @@ public class AwsS3ImageEventHandler {
 
 	private final ImageManager imageManager;
 
-	public AwsS3ImageEventHandler(ImageManager imageManager) {
+	public AwsS3ImageEventHandler(@Qualifier("awsS3ImageManager") ImageManager imageManager) {
 		this.imageManager = imageManager;
 	}
 

--- a/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
@@ -1,0 +1,41 @@
+package univ.earthbreaker.namu.external.image;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import feign.Response;
+import univ.earthbreaker.namu.external.aws.image.ImageManager;
+import univ.earthbreaker.namu.external.aws.image.ImageUploadCommand;
+import univ.earthbreaker.namu.external.server.ExternalImageResponse;
+
+@Component
+public class ExternalImageManager implements ImageManager {
+
+	private final ImageApiCaller imageApiCaller;
+
+	public ExternalImageManager(ImageApiCaller imageApiCaller) {
+		this.imageApiCaller = imageApiCaller;
+	}
+
+	@Override
+	public String upload(ImageUploadCommand command) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		Response response = imageApiCaller.uploadImage();
+		String result;
+		try {
+			ExternalImageResponse body = objectMapper.readValue(response.body().asInputStream(), ExternalImageResponse.class);
+			result = body.message();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		return result;
+	}
+
+	@Override
+	public void delete(String imagePathKey) {
+		Response response = imageApiCaller.deleteImage();
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
@@ -1,0 +1,19 @@
+package univ.earthbreaker.namu.external.image;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import feign.Response;
+
+@FeignClient(
+	name = "imageApiCaller",
+	url = "http://localhost:8080/external/image/",
+	configuration = ImageFeignConfiguration.class)
+public interface ImageApiCaller {
+
+	@PostMapping(value = "/upload/success")
+	Response uploadImage();
+
+	@PostMapping(value = "/delete/success")
+	Response deleteImage();
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignConfiguration.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignConfiguration.java
@@ -1,0 +1,9 @@
+package univ.earthbreaker.namu.external.image;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients
+@Configuration
+public class ImageFeignConfiguration {
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageApiServer.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageApiServer.java
@@ -1,0 +1,44 @@
+package univ.earthbreaker.namu.external.server;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/external/image/")
+public class ExternalImageApiServer {
+
+	private final RandomLatencyImageManager randomLatencyImageManager;
+
+	public ExternalImageApiServer(RandomLatencyImageManager randomLatencyImageManager) {
+		this.randomLatencyImageManager = randomLatencyImageManager;
+	}
+
+	@PostMapping("/upload/success")
+	public ResponseEntity<ExternalImageResponse> uploadSuccess() {
+		String result = randomLatencyImageManager.uploadImage("", "");
+		return new ResponseEntity<>(
+			new ExternalImageResponse(200, result),
+			HttpStatusCode.valueOf(200)
+		);
+	}
+
+	@PostMapping("/upload/fail")
+	public ResponseEntity<ExternalImageResponse> uploadFail() {
+		return new ResponseEntity<>(
+			new ExternalImageResponse(400, "image upload fail"),
+			HttpStatusCode.valueOf(400)
+		);
+	}
+
+	@PostMapping("/delete/success")
+	public ResponseEntity<ExternalImageResponse> deleteSuccess() {
+		String result = randomLatencyImageManager.deleteImage("");
+		return new ResponseEntity<>(
+			new ExternalImageResponse(200, result),
+			HttpStatusCode.valueOf(200)
+		);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageResponse.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageResponse.java
@@ -1,0 +1,4 @@
+package univ.earthbreaker.namu.external.server;
+
+public record ExternalImageResponse(int code, String message) {
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageServerException.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageServerException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.external.server;
+
+public class ExternalImageServerException extends RuntimeException {
+
+	public ExternalImageServerException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageStorage.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageStorage.java
@@ -1,0 +1,36 @@
+package univ.earthbreaker.namu.external.server;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExternalImageStorage {
+
+	private final Map<String, String> storage = new HashMap<>();
+
+	public String upload(String imageKey, String imageData) {
+		if (storage.get(imageKey) != null) { // 중복 검사
+			throw new ExternalImageServerException("이미 저장된 이미지입니다");
+		}
+		storage.put(imageKey, imageData);
+		return imageKey;
+	}
+
+	public void delete(String imageKey) {
+		if (storage.remove(imageKey) == null) {
+			throw new ExternalImageServerException("Image with Key " + imageKey + " not found.");
+		}
+	}
+
+	public String download(String imageKey) {
+		if (imageKey == null) {
+			throw new ExternalImageServerException("Image ID must not be null.");
+		}
+
+		String imageData = storage.get(imageKey);
+		if (imageData == null) {
+			throw new ExternalImageServerException("Image with ID " + imageKey + " not found.");
+		}
+
+		return imageData;
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/RandomLatencyImageManager.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/RandomLatencyImageManager.java
@@ -1,0 +1,54 @@
+package univ.earthbreaker.namu.external.server;
+
+import java.util.Random;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 응답 지연시간이 100ms 에서 10000ms 로 랜덤한,
+ * 동기적으로 동작하는 외부 이미지 서버 API 라고 가정
+ */
+@Component
+public class RandomLatencyImageManager {
+
+	private static final int MIN_DELAY_MS = 100; // 최소 지연 시간
+	private static final int MAX_DELAY_MS = 10_000; // 최대 지연 시간
+
+	private final Random random = new Random();
+
+	/**
+	 * 동기적으로 이미지를 업로드하는 메서드.
+	 * @param s1
+	 * @param s2
+	 * @return 업로드 결과 메시지
+	 * @throws InterruptedException 지연 시 예외 발생 가능
+	 */
+	public String uploadImage(String s1, String s2) {
+		// 랜덤한 지연 시간 생성 (100ms ~ 10000ms)
+		int delay = random.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+
+		// 지연 시뮬레이션
+		try {
+			Thread.sleep(delay);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+
+		// 업로드 처리 결과 반환
+		return "Image uploaded successfully after " + delay + "ms";
+	}
+
+	public String deleteImage(String imagePathKey) {
+		// 랜덤한 지연 시간 생성 (100ms ~ 10000ms)
+		int delay = random.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+
+		// 지연 시뮬레이션
+		try {
+			Thread.sleep(delay);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+
+		return "Image deleted successfully after " + delay + "ms";
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/RandomLatencyImageManager.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/RandomLatencyImageManager.java
@@ -11,44 +11,66 @@ import org.springframework.stereotype.Component;
 @Component
 public class RandomLatencyImageManager {
 
+	private static final ExternalImageStorage STORAGE = new ExternalImageStorage();
+	private static final Random RANDOM = new Random();
+
 	private static final int MIN_DELAY_MS = 100; // 최소 지연 시간
 	private static final int MAX_DELAY_MS = 10_000; // 최대 지연 시간
-
-	private final Random random = new Random();
+	private static final double EXCEPTION_PROBABILITY = 0.1; // 예외 발생 확률 (10%)
 
 	/**
-	 * 동기적으로 이미지를 업로드하는 메서드.
-	 * @param s1
-	 * @param s2
+	 * 동기적으로 이미지를 업로드
+	 * @param imageKey 이미지 키
+	 * @param imageData 이미지 파일 데이터
 	 * @return 업로드 결과 메시지
-	 * @throws InterruptedException 지연 시 예외 발생 가능
 	 */
-	public String uploadImage(String s1, String s2) {
-		// 랜덤한 지연 시간 생성 (100ms ~ 10000ms)
-		int delay = random.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+	public String uploadImage(String imageKey, String imageData) {
+		int delay = getDelay();
+		delaySimulation(delay);
+		invokeException();
 
-		// 지연 시뮬레이션
-		try {
-			Thread.sleep(delay);
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-
-		// 업로드 처리 결과 반환
-		return "Image uploaded successfully after " + delay + "ms";
+		String uploadedImageKey = STORAGE.upload(imageKey, imageData);
+		return uploadedImageKey + " image uploaded successfully after " + delay + "ms";
 	}
 
-	public String deleteImage(String imagePathKey) {
-		// 랜덤한 지연 시간 생성 (100ms ~ 10000ms)
-		int delay = random.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+	/**
+	 * @param imageKey 이미지 키
+	 * @return 삭제 결과 메시지
+	 */
+	public String deleteImage(String imageKey) {
+		int delay = getDelay();
+		delaySimulation(delay);
+		invokeException();
 
-		// 지연 시뮬레이션
+		STORAGE.delete(imageKey);
+		return "Image deleted successfully after " + delay + "ms";
+	}
+
+	/**
+	 * @return 랜덤한 지연 시간 (100ms ~ 10000ms)
+	 */
+	private int getDelay() {
+		return RANDOM.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+	}
+
+	/**
+	 * 지연 시뮬레이션
+	 * @param delay 지연시간
+	 */
+	private void delaySimulation(int delay) {
 		try {
 			Thread.sleep(delay);
 		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
+			throw new ExternalImageServerException(e.getMessage());
 		}
+	}
 
-		return "Image deleted successfully after " + delay + "ms";
+	/**
+	 * 10% 확률로 실패 발생시키기
+	 */
+	private void invokeException() {
+		if (RANDOM.nextDouble() < EXCEPTION_PROBABILITY) {
+			throw new ExternalImageServerException("Simulated exception during image upload");
+		}
 	}
 }


### PR DESCRIPTION
## 주요 작업 내용

### external.server 패키지

이미치 처리에 외부 서버를 이용한다고 가정하고, 
이미지 `업로드`, `삭제` 기능을 제공하는 임의의 외부 서버를 직접 만들어서 사용합니다

### 관련 이슈
- #108 