### PR TITLE
통제 불가능한 외부 이미지 서버 문제 대응하기 (base/issue/107 브랜치에서 작업해서 수정)

### DIFF
--- a/src/main/java/univ/earthbreaker/namu/core/api/config/ThreadPoolConfiguration.java
+++ b/src/main/java/univ/earthbreaker/namu/core/api/config/ThreadPoolConfiguration.java
@@ -1,0 +1,28 @@
+package univ.earthbreaker.namu.core.api.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThreadPoolConfiguration {
+
+	private static final int CORE_POOL_SIZE = 10;
+	private static final int MAX_POOL_SIZE = 50;
+	private static final int QUEUE_CAPACITY = 10;
+	private static final String THREAD_NAME_PREFIX = "async-";
+
+	@Bean(name = "threadPoolExecutor")
+	public Executor asyncExecutor() {
+		ThreadPoolTaskExecutor threadPoolTask = new ThreadPoolTaskExecutor();
+		threadPoolTask.setCorePoolSize(CORE_POOL_SIZE);
+		threadPoolTask.setMaxPoolSize(MAX_POOL_SIZE);
+		threadPoolTask.setQueueCapacity(QUEUE_CAPACITY);
+		threadPoolTask.setWaitForTasksToCompleteOnShutdown(true);
+		threadPoolTask.setThreadNamePrefix(THREAD_NAME_PREFIX);
+		threadPoolTask.initialize();
+		return threadPoolTask;
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/core/api/mission/MissionCertifyController.java
+++ b/src/main/java/univ/earthbreaker/namu/core/api/mission/MissionCertifyController.java
@@ -1,5 +1,8 @@
 package univ.earthbreaker.namu.core.api.mission;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,7 +16,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import univ.earthbreaker.namu.core.api.auth.support.AuthMapping;
 import univ.earthbreaker.namu.core.api.auth.support.LoginMember;
+import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 import univ.earthbreaker.namu.external.aws.image.ImageManager;
 import univ.earthbreaker.namu.external.aws.image.ImagePathKeyGenerator;
 import univ.earthbreaker.namu.external.aws.image.ImageUploadCommand;
@@ -25,15 +30,18 @@ public class MissionCertifyController {
 	private final ImageManager imageManager;
 	private final ImagePathKeyGenerator imagePathKeyGenerator;
 	private final MemberMissionCertifyService missionCertifyService;
+	private final Executor executor;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
 		@Qualifier("missionPostImagePathGen") ImagePathKeyGenerator imagePathKeyGenerator,
-		MemberMissionCertifyService missionCertifyService
+		MemberMissionCertifyService missionCertifyService,
+		Executor threadPoolExecutor
 	) {
 		this.imageManager = imageManager;
 		this.imagePathKeyGenerator = imagePathKeyGenerator;
 		this.missionCertifyService = missionCertifyService;
+		this.executor = threadPoolExecutor;
 	}
 
 	@AuthMapping
@@ -44,7 +52,19 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		String result = imageManager.upload(ImageUploadCommand.forMember(memberNo, missionImageFile, imagePathKeyGenerator));
-		return ResponseEntity.status(HttpStatus.CREATED).body(result);
+		CompletableFuture.supplyAsync(
+				() -> imageManager.upload(ImageUploadCommand.forMember(memberNo, missionImageFile, imagePathKeyGenerator)),
+				executor
+			)
+			.exceptionally(ex -> null)
+			.thenAccept(result -> {
+				if (result != null) {
+					missionCertifyService.successMission(
+						new MissionCompleteCommand(memberNo, missionNo),
+						new CertifiedMissionPostCommand(memberNo, content, result)
+					);
+				}
+			});
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 }

--- a/src/main/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyService.java
+++ b/src/main/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyService.java
@@ -1,25 +1,18 @@
 package univ.earthbreaker.namu.core.domain.mission;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import univ.earthbreaker.namu.event.EventPublisher;
-import univ.earthbreaker.namu.event.image.DeleteUploadedImageEvent;
+import univ.earthbreaker.namu.event.image.DeleteExternalUploadedImageEvent;
 import univ.earthbreaker.namu.event.point.AddRewardPointEvent;
 import univ.earthbreaker.namu.event.post.PostCreateEvent;
 
 @Service
 public class MemberMissionCertifyService {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(MemberMissionCertifyService.class);
-	private static final AtomicBoolean IS_ROLLBACK = new AtomicBoolean(false);
 
 	private final MemberMissionFinder memberMissionFinder;
 	private final MissionCertifyHandler missionCertifyHandler;
@@ -42,29 +35,24 @@ public class MemberMissionCertifyService {
 		@NotNull MissionCompleteCommand missionCommand,
 		@NotNull CertifiedMissionPostCommand postCommand
 	) {
-		transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-			@Override
-			protected void doInTransactionWithoutResult(@NotNull TransactionStatus status) {
-				try {
+		try {
+			transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+				@Override
+				protected void doInTransactionWithoutResult(@NotNull TransactionStatus status) {
 					MemberMission memberMission = memberMissionFinder.find(
 						missionCommand.getMemberNo(), missionCommand.getMissionNo());
 					MemberMission successMission = missionCertifyHandler.success(memberMission);
 					publishRewardEventForSuccessMission(successMission);
 					publishCreatePostEventForSuccessMission(postCommand, successMission);
-				} catch (Exception e) {
-					LOGGER.info("예외 발생으로 인한 트랜잭션 롤백 및 이미지 삭제 : {}", e.getMessage());
-					status.setRollbackOnly();
-					IS_ROLLBACK.set(status.isRollbackOnly());
 				}
-			}
-		});
-		publishDeleteUploadImageEventWhenTransactionRollback(postCommand.getImagePathKey());
+			});
+		} catch (Exception e) {
+			publishDeleteUploadImageEventWhenTransactionRollback(postCommand.getImagePathKey());
+		}
 	}
 
 	private void publishDeleteUploadImageEventWhenTransactionRollback(@NotNull String imagePathKey) {
-		if (IS_ROLLBACK.get()) {
-			eventPublisher.publish(new DeleteUploadedImageEvent(imagePathKey));
-		}
+		eventPublisher.publish(new DeleteExternalUploadedImageEvent(imagePathKey));
 	}
 
 	private void publishRewardEventForSuccessMission(@NotNull MemberMission successMission) {

--- a/src/main/java/univ/earthbreaker/namu/event/image/DeleteExternalUploadedImageEvent.java
+++ b/src/main/java/univ/earthbreaker/namu/event/image/DeleteExternalUploadedImageEvent.java
@@ -1,0 +1,4 @@
+package univ.earthbreaker.namu.event.image;
+
+public record DeleteExternalUploadedImageEvent(String imageKey) {
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageEventHandler.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageEventHandler.java
@@ -1,0 +1,22 @@
+package univ.earthbreaker.namu.external.image;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import univ.earthbreaker.namu.event.image.DeleteExternalUploadedImageEvent;
+
+@Component
+public class ExternalImageEventHandler {
+
+	private final ExternalImageManager imageManager;
+
+	public ExternalImageEventHandler(ExternalImageManager imageManager) {
+		this.imageManager = imageManager;
+	}
+
+	@EventListener
+	public void deleteImage(@NotNull DeleteExternalUploadedImageEvent event) {
+		imageManager.delete(event.imageKey());
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
@@ -1,12 +1,7 @@
 package univ.earthbreaker.namu.external.image;
 
-import java.io.IOException;
-
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import feign.Response;
 import univ.earthbreaker.namu.external.aws.image.ImageManager;
 import univ.earthbreaker.namu.external.aws.image.ImageUploadCommand;
 import univ.earthbreaker.namu.external.server.ExternalImageResponse;
@@ -22,20 +17,12 @@ public class ExternalImageManager implements ImageManager {
 
 	@Override
 	public String upload(ImageUploadCommand command) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		Response response = imageApiCaller.uploadImage();
-		String result;
-		try {
-			ExternalImageResponse body = objectMapper.readValue(response.body().asInputStream(), ExternalImageResponse.class);
-			result = body.message();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-		return result;
+		ExternalImageResponse response = imageApiCaller.uploadImage();
+		return response.message();
 	}
 
 	@Override
 	public void delete(String imagePathKey) {
-		Response response = imageApiCaller.deleteImage();
+		imageApiCaller.deleteImage();
 	}
 }

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
@@ -3,7 +3,7 @@ package univ.earthbreaker.namu.external.image;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import feign.Response;
+import univ.earthbreaker.namu.external.server.ExternalImageResponse;
 
 @FeignClient(
 	name = "imageApiCaller",
@@ -11,9 +11,9 @@ import feign.Response;
 	configuration = ImageFeignConfiguration.class)
 public interface ImageApiCaller {
 
-	@PostMapping(value = "/upload/success")
-	Response uploadImage();
+	@PostMapping(value = "/upload")
+	ExternalImageResponse uploadImage();
 
-	@PostMapping(value = "/delete/success")
-	Response deleteImage();
+	@PostMapping(value = "/delete")
+	ExternalImageResponse deleteImage();
 }

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignConfiguration.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignConfiguration.java
@@ -1,9 +1,34 @@
 package univ.earthbreaker.namu.external.image;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import feign.Request;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
 
 @EnableFeignClients
 @Configuration
 public class ImageFeignConfiguration {
+
+	private static final long CONNECTION_TIMEOUT = 3_000;
+	private static final long READ_TIMEOUT = 10_000;
+
+	@Bean(name = "feignRequestTimeoutOptions")
+	Request.Options requestOptions() {
+		return new Request.Options(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS, READ_TIMEOUT, TimeUnit.MILLISECONDS, false);
+	}
+
+	@Bean(name = "imageRetryer")
+	public Retryer retryer() {
+		return Retryer.NEVER_RETRY;
+	}
+
+	@Bean(name = "imageErrorDecoder")
+	ErrorDecoder errorDecoder() {
+		return new ImageFeignExceptionDecoder();
+	}
 }

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignExceptionDecoder.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageFeignExceptionDecoder.java
@@ -1,0 +1,20 @@
+package univ.earthbreaker.namu.external.image;
+
+import org.springframework.http.HttpStatus;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class ImageFeignExceptionDecoder implements ErrorDecoder {
+
+	@Override
+	public Exception decode(String methodKey, Response response) {
+		HttpStatus status = HttpStatus.resolve(response.status());
+		if (status == HttpStatus.BAD_REQUEST) {
+			throw new ImageServerBadRequestException(
+				String.format("[이미지 서버 API BAD_REQUEST] %s : %s", methodKey, response.reason()));
+		}
+		throw new ImageServerServerException(
+			String.format("[이미지 서버 API SERVER_ERROR] %s : %s", methodKey, response.reason()));
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageServerBadRequestException.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageServerBadRequestException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.external.image;
+
+public class ImageServerBadRequestException extends RuntimeException {
+
+	public ImageServerBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/image/ImageServerServerException.java
+++ b/src/main/java/univ/earthbreaker/namu/external/image/ImageServerServerException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.external.image;
+
+public class ImageServerServerException extends RuntimeException {
+
+	public ImageServerServerException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalBadRequestException.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalBadRequestException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.external.server;
+
+public class ExternalBadRequestException extends RuntimeException {
+
+	public ExternalBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageApiServer.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageApiServer.java
@@ -1,6 +1,6 @@
 package univ.earthbreaker.namu.external.server;
 
-import org.springframework.http.HttpStatusCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,29 +16,15 @@ public class ExternalImageApiServer {
 		this.randomLatencyImageManager = randomLatencyImageManager;
 	}
 
-	@PostMapping("/upload/success")
+	@PostMapping("/upload")
 	public ResponseEntity<ExternalImageResponse> uploadSuccess() {
 		String result = randomLatencyImageManager.uploadImage("", "");
-		return new ResponseEntity<>(
-			new ExternalImageResponse(200, result),
-			HttpStatusCode.valueOf(200)
-		);
+		return ResponseEntity.ok(new ExternalImageResponse(HttpStatus.OK.value(), result));
 	}
 
-	@PostMapping("/upload/fail")
-	public ResponseEntity<ExternalImageResponse> uploadFail() {
-		return new ResponseEntity<>(
-			new ExternalImageResponse(400, "image upload fail"),
-			HttpStatusCode.valueOf(400)
-		);
-	}
-
-	@PostMapping("/delete/success")
+	@PostMapping("/delete")
 	public ResponseEntity<ExternalImageResponse> deleteSuccess() {
 		String result = randomLatencyImageManager.deleteImage("");
-		return new ResponseEntity<>(
-			new ExternalImageResponse(200, result),
-			HttpStatusCode.valueOf(200)
-		);
+		return ResponseEntity.ok(new ExternalImageResponse(HttpStatus.OK.value(), result));
 	}
 }

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageServerExceptionHandler.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageServerExceptionHandler.java
@@ -1,0 +1,25 @@
+package univ.earthbreaker.namu.external.server;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExternalImageServerExceptionHandler {
+
+	@ExceptionHandler(ExternalBadRequestException.class)
+	public ResponseEntity<ExternalImageResponse> handle400Exception(ExternalBadRequestException exception) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(new ExternalImageResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()));
+	}
+
+	@ExceptionHandler(ExternalImageServerException.class)
+	public ResponseEntity<ExternalImageResponse> handle500Exception(ExternalImageServerException exception) {
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ExternalImageResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.getMessage()));
+	}
+}
+

--- a/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageStorage.java
+++ b/src/main/java/univ/earthbreaker/namu/external/server/ExternalImageStorage.java
@@ -9,7 +9,7 @@ public class ExternalImageStorage {
 
 	public String upload(String imageKey, String imageData) {
 		if (storage.get(imageKey) != null) { // 중복 검사
-			throw new ExternalImageServerException("이미 저장된 이미지입니다");
+			throw new ExternalBadRequestException("이미 저장된 이미지입니다");
 		}
 		storage.put(imageKey, imageData);
 		return imageKey;
@@ -17,13 +17,13 @@ public class ExternalImageStorage {
 
 	public void delete(String imageKey) {
 		if (storage.remove(imageKey) == null) {
-			throw new ExternalImageServerException("Image with Key " + imageKey + " not found.");
+			throw new ExternalBadRequestException("Image with Key " + imageKey + " not found.");
 		}
 	}
 
 	public String download(String imageKey) {
 		if (imageKey == null) {
-			throw new ExternalImageServerException("Image ID must not be null.");
+			throw new ExternalBadRequestException("Image ID must not be null.");
 		}
 
 		String imageData = storage.get(imageKey);

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -3669,7 +3669,7 @@ Host: namu.api.docs
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-14 23:44:33 +0900
+Last updated 2024-10-06 12:24:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/overview.html
+++ b/src/main/resources/static/docs/overview.html
@@ -525,7 +525,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-14 23:44:33 +0900
+Last updated 2024-10-06 12:24:34 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/post-api.html
+++ b/src/main/resources/static/docs/post-api.html
@@ -899,7 +899,7 @@ Content-Length: 379
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-14 23:44:33 +0900
+Last updated 2024-10-06 12:24:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/reaction-api.html
+++ b/src/main/resources/static/docs/reaction-api.html
@@ -717,7 +717,7 @@ Host: namu.api.docs
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-05-14 23:44:33 +0900
+Last updated 2024-10-06 12:24:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyServiceTest.java
+++ b/src/test/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import univ.earthbreaker.namu.event.EventPublisher;
-import univ.earthbreaker.namu.event.image.DeleteUploadedImageEvent;
+import univ.earthbreaker.namu.event.image.DeleteExternalUploadedImageEvent;
 import univ.earthbreaker.namu.event.point.AddRewardPointEvent;
 import univ.earthbreaker.namu.event.post.PostCreateEvent;
 
@@ -104,7 +104,7 @@ class MemberMissionCertifyServiceTest {
 		);
 
 	    // then
-		verify(eventPublisher).publish(new DeleteUploadedImageEvent(MISSION_POST_IMAGE_PATH_KEY));
+		verify(eventPublisher).publish(new DeleteExternalUploadedImageEvent(MISSION_POST_IMAGE_PATH_KEY));
 	}
 
 	@DisplayName("회원의 인증 성공한 미션을 찾아와 '미션 실패'상태로 변경한다")


### PR DESCRIPTION
## 주요 작업 내용

- 외부 이미지 업로드 요청 CompletableFuture 를 통해 비동기로 처리
  - 비즈니스 로직(게시글 업로드 + 포인트 지급)은 callback 으로 등록
  - HTTP Early Return 으로 사용자에게 빠르게 응답
- 외부 서버 API call 실패 시 재시도 하지 않도록 설정

## 실패 시나리오 및 대응 방안
1. 네트워크 connection-timeout, read-timeout 으로 인한 실패
    - 업로드 요청 재시도 안함
2. 외부 서버에서 발생한 문제로 인한 실패
    - 그냥 실패 처리
        - CompletableFuture 비동기 처리 이후 콜백 메서드(비즈니스 로직) 실행하지 않고 바로 종료

## 추가 보완이 필요한 부분
- HTTP Early Return 메시지 구체화
  - 비동기로 처리되는 작업들의 결과를 실시간으로 클라이언트에게 전송
- 사용자 재시도 요청 시 멱등성을 보장하기 위한 메커니즘
- 실패 시나리오 및 대응 방안 추가
  - 네트워크 혼선으로 외부 서버 지연 처리되는 경우 : 우리 서버는 결과를 알지 못하는 상태
  - 비즈니스 로직이 실패하여 TX 가 롤백되는 경우

## 관련 이슈
- #107 
- #108 
- #112 