### PR TITLE
[외부 이미지 서버로 교체 시 발생하는 문제 해결 1] 프로그래밍 방식 트랜잭션 관리 - TransactionHandler 도입

### DIFF
--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyService.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MemberMissionCertifyService.java
@@ -2,12 +2,9 @@ package univ.earthbreaker.namu.core.domain.mission;
 
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
-import org.springframework.transaction.support.TransactionTemplate;
 
+import univ.earthbreaker.namu.core.support.TransactionHandler;
 import univ.earthbreaker.namu.event.EventPublisher;
-import univ.earthbreaker.namu.event.image.DeleteExternalUploadedImageEvent;
 import univ.earthbreaker.namu.event.point.AddRewardPointEvent;
 import univ.earthbreaker.namu.event.post.PostCreateEvent;
 
@@ -17,42 +14,31 @@ public class MemberMissionCertifyService {
 	private final MemberMissionFinder memberMissionFinder;
 	private final MissionCertifyHandler missionCertifyHandler;
 	private final EventPublisher eventPublisher;
-	private final TransactionTemplate transactionTemplate;
+	private final TransactionHandler transactionHandler;
 
 	public MemberMissionCertifyService(
 		MemberMissionFinder memberMissionFinder,
 		MissionCertifyHandler missionCertifyHandler,
 		EventPublisher eventPublisher,
-		TransactionTemplate transactionTemplate
+		TransactionHandler transactionHandler
 	) {
 		this.memberMissionFinder = memberMissionFinder;
 		this.missionCertifyHandler = missionCertifyHandler;
 		this.eventPublisher = eventPublisher;
-		this.transactionTemplate = transactionTemplate;
+		this.transactionHandler = transactionHandler;
 	}
 
 	public void successMission(
-		@NotNull MissionCompleteCommand missionCommand,
-		@NotNull CertifiedMissionPostCommand postCommand
+		@NotNull MissionCompleteCommand mc,
+		@NotNull CertifiedMissionPostCommand pc
 	) {
-		try {
-			transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-				@Override
-				protected void doInTransactionWithoutResult(@NotNull TransactionStatus status) {
-					MemberMission memberMission = memberMissionFinder.find(
-						missionCommand.getMemberNo(), missionCommand.getMissionNo());
-					MemberMission successMission = missionCertifyHandler.success(memberMission);
-					publishRewardEventForSuccessMission(successMission);
-					publishCreatePostEventForSuccessMission(postCommand, successMission);
-				}
-			});
-		} catch (Exception e) {
-			publishDeleteUploadImageEventWhenTransactionRollback(postCommand.getImagePathKey());
-		}
-	}
-
-	private void publishDeleteUploadImageEventWhenTransactionRollback(@NotNull String imagePathKey) {
-		eventPublisher.publish(new DeleteExternalUploadedImageEvent(imagePathKey));
+		transactionHandler.execute(() -> {
+			MemberMission memberMission = memberMissionFinder.find(mc.getMemberNo(), mc.getMissionNo());
+			MemberMission successMission = missionCertifyHandler.success(memberMission);
+			publishRewardEventForSuccessMission(successMission); // 리워드 포인트 지급 이벤트 발행
+			publishCreatePostEventForSuccessMission(pc, successMission); // 게시글 생성 이벤트 발행
+			return null;
+		});
 	}
 
 	private void publishRewardEventForSuccessMission(@NotNull MemberMission successMission) {

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/point/EnergyPointEventHandler.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/point/EnergyPointEventHandler.java
@@ -1,7 +1,6 @@
 package univ.earthbreaker.namu.core.domain.point;
 
 import org.jetbrains.annotations.NotNull;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -18,7 +17,7 @@ public class EnergyPointEventHandler {
 		this.energyPointRepository = energyPointRepository;
 	}
 
-	@EventListener
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
 	public void giveRewardPoint(@NotNull AddRewardPointEvent event) {
 		PointUpdateDbCommand command = new PointUpdateDbCommand(event.memberNo(), event.point());
 		energyPointRepository.receivePoint(command);

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/post/PostCreateEventHandler.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/post/PostCreateEventHandler.java
@@ -1,8 +1,9 @@
 package univ.earthbreaker.namu.core.domain.post;
 
 import org.jetbrains.annotations.NotNull;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import univ.earthbreaker.namu.event.post.PostCreateEvent;
 
@@ -17,7 +18,7 @@ public class PostCreateEventHandler {
 		this.postRepository = postRepository;
 	}
 
-	@EventListener
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
 	public void createPost(@NotNull PostCreateEvent event) {
 		PostMemberBridge.PostMemberDto postMemberInfo = postMemberBridge.findMemberInfo(event.memberNo());
 		PostCreateDbCommand createCommand = new PostCreateDbCommand(

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionAction.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionAction.java
@@ -1,0 +1,6 @@
+package univ.earthbreaker.namu.core.support;
+
+@FunctionalInterface
+public interface TransactionAction<T> {
+	T action();
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionHandler.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionHandler.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.core.support;
+
+import org.springframework.transaction.TransactionException;
+
+public interface TransactionHandler {
+	<T> T execute(TransactionAction<T> action) throws TransactionException;
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionHandlerAdapter.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/support/TransactionHandlerAdapter.java
@@ -1,0 +1,20 @@
+package univ.earthbreaker.namu.core.support;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+class TransactionHandlerAdapter implements TransactionHandler {
+
+	private final TransactionTemplate transactionTemplate;
+
+	public TransactionHandlerAdapter(TransactionTemplate transactionTemplate) {
+		this.transactionTemplate = transactionTemplate;
+	}
+
+	@Override
+	public <T> T execute(TransactionAction<T> action) throws TransactionException {
+		return transactionTemplate.execute(status -> action.action());
+	}
+}


### PR DESCRIPTION
## 주요 컴포넌트

- `TransactionHandler` 인터페이스 도입 (도메인에서 사용할 추상화)
- `TransactionHandlerAdapter` 구현체 도입 (Spring TransactionOperations 기반의 TransactionTemplate 사용)
- `@FunctionalInterface` 형태의 `TransactionAction<T>` 정의 → 트랜잭션 경계 내 실행할 람다 전달용

## 프로그래매틱 트랜잭션 관리

> @Transactional어노테이션 기반은 method 단위이다보니 그 유연함이 떨어져 클래스를 나누는 등에 방식으로 파생되면서 복잡도가 오르는 이슈가 있습니다.
위 피드백에 대한 반영으로 tx scope 관리를 조금 더 유연하게 풀기 위해 위와 같은 구조를 도입했습니다.
비즈니스 레이어에서 트랜잭션을 세밀하게 제어해야 하는 경우 기존보다 더 유연한 코드 작성이 가능할 것으로 예상됩니다.


## 현재 PR로 인해 수정된 부분

<img width="800" height="550" alt="스크린샷 2025-07-17 오후 2 39 20" src="https://github.com/user-attachments/assets/f7644e8d-1f79-451b-b7be-9de28878aed7" />

image upload 요청 이후, `미션성공처리 + 포인트 지급 + 게시글 생성` 로직을 수행하는 부분에 대한 PR 입니다.
기존 코드에서는 비즈니스 로직 수행 중 예외 발생으로 인한 트랜잭션 롤백 발생 시, 업로드된 이미지를 삭제하는 이벤트를 발행했습니다.
위와 같이 외부 이미지 서버로 대체 시, 이미지 삭제 요청 실패 or 네트워크 타임아웃 등에 대한 추가적인 대응 비용이 필요합니다. 
따라서 "업로드된 이미지 삭제 이벤트 발행"은 제거하고 Retry 를 통해 해결할 생각입니다.

### ⚠️ 
다만, "업로드된 이미지 삭제 이벤트 발행"을 제거하면 `@Transactional` 을 붙여주는 것 만으로도 해결이 되긴 합니다.