### PR TITLE
[외부 이미지 서버로 교체 시 발생하는 문제 해결 2] HTTP 스레드 점유 문제 해결 - SSE 방식

### DIFF
--- a/app/api/build.gradle
+++ b/app/api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(":clients:oauth")
 //    implementation project(":clients:aws")
     implementation project(":clients:image")
+    implementation project(":clients:sse")
 
     implementation project(":support:logging")
 

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import univ.earthbreaker.namu.app.support.AuthMapping;
 import univ.earthbreaker.namu.app.support.LoginMember;
+import univ.earthbreaker.namu.clients.sse.SseAlerter;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
@@ -29,15 +30,18 @@ public class MissionCertifyController {
 	private final ImageManager imageManager;
 	private final MemberMissionCertifyService missionCertifyService;
 	private final Executor executor;
+	private final SseAlerter sseAlerter;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
 		MemberMissionCertifyService missionCertifyService,
-		Executor threadPoolExecutor
+		Executor threadPoolExecutor,
+		SseAlerter sseAlerter
 	) {
 		this.imageManager = imageManager;
 		this.missionCertifyService = missionCertifyService;
 		this.executor = threadPoolExecutor;
+		this.sseAlerter = sseAlerter;
 	}
 
 	@AuthMapping
@@ -48,18 +52,28 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		CompletableFuture.supplyAsync(
-				() -> imageManager.upload(new ImageUploadCommand()),
-				executor
-			)
-			.exceptionally(ex -> null)
-			.thenAccept(result -> {
-				if (result != null) {
-					missionCertifyService.successMission(
-						new MissionCompleteCommand(memberNo, missionNo),
-						new CertifiedMissionPostCommand(memberNo, content, result)
-					);
+		CompletableFuture
+			.supplyAsync(() -> {
+				String imageUrl = imageManager.retrieve(missionImageFile);
+				if (imageUrl != null) {
+					return imageUrl;
+				} else {
+					return imageManager.upload(new ImageUploadCommand());
 				}
+			}, executor)
+			.thenAccept(imageUrl -> {
+				if (imageUrl == null) {
+					throw MissionServerException.missingImageUrl();
+				}
+				missionCertifyService.successMission(
+					new MissionCompleteCommand(memberNo, missionNo),
+					new CertifiedMissionPostCommand(memberNo, content, imageUrl)
+				);
+				sseAlerter.alert(memberNo, "MISSION_API_SUCCESS", null);
+			})
+			.exceptionally(ex -> {
+				sseAlerter.alert(memberNo, "MISSION_API_FAILED", ex.getMessage());
+				return null;
 			});
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -75,6 +75,6 @@ public class MissionCertifyController {
 				sseAlerter.alert(memberNo, "MISSION_API_FAILED", ex.getMessage());
 				return null;
 			});
-		return ResponseEntity.status(HttpStatus.CREATED).build();
+		return ResponseEntity.status(HttpStatus.ACCEPTED).build();
 	}
 }

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionServerException.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionServerException.java
@@ -1,0 +1,12 @@
+package univ.earthbreaker.namu.app.api.mission;
+
+public class MissionServerException extends RuntimeException {
+
+	public MissionServerException(String message) {
+		super(message);
+	}
+
+	static MissionServerException missingImageUrl() {
+		return new MissionServerException("Image upload returned null");
+	}
+}

--- a/clients/sse/build.gradle
+++ b/clients/sse/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    compileOnly 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}

--- a/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SendRequest.java
+++ b/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SendRequest.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.clients.sse;
+
+public record SendRequest(
+	String eventName,
+	Object data
+) {
+}

--- a/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SseAlerter.java
+++ b/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SseAlerter.java
@@ -1,0 +1,17 @@
+package univ.earthbreaker.namu.clients.sse;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SseAlerter {
+
+	private final SseApiCaller apiCaller;
+
+	public SseAlerter(SseApiCaller apiCaller) {
+		this.apiCaller = apiCaller;
+	}
+
+	public void alert(Long userId, String eventName, Object data) {
+		apiCaller.send(userId, new SendRequest(eventName, data));
+	}
+}

--- a/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SseApiCaller.java
+++ b/clients/sse/src/main/java/univ/earthbreaker/namu/clients/sse/SseApiCaller.java
@@ -1,0 +1,21 @@
+package univ.earthbreaker.namu.clients.sse;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+	name = "sseApiCaller",
+	url = "http://localhost:8083/internal/sse")
+@Component
+public interface SseApiCaller {
+
+	@GetMapping("/subscribe/{userId}")
+	void subscribe(@PathVariable Long userId);
+
+	@PostMapping("/send/{userId}")
+	void send(@PathVariable Long userId, @RequestBody SendRequest request);
+}

--- a/server/internal/build.gradle
+++ b/server/internal/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(':support:logging')
+}

--- a/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/InternalSseServerApplication.java
+++ b/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/InternalSseServerApplication.java
@@ -1,0 +1,12 @@
+package univ.earthbreaker.namu.server.internal;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InternalSseServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(InternalSseServerApplication.class, args);
+	}
+}

--- a/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/api/InternalSseApiServer.java
+++ b/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/api/InternalSseApiServer.java
@@ -1,0 +1,34 @@
+package univ.earthbreaker.namu.server.internal.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import univ.earthbreaker.namu.server.internal.service.SseService;
+
+@RestController
+@RequestMapping("/internal/sse")
+public class InternalSseApiServer {
+
+	private final SseService sseService;
+
+	public InternalSseApiServer(SseService sseService) {
+		this.sseService = sseService;
+	}
+
+	@GetMapping("/subscribe/{userId}")
+	public ResponseEntity<Void> subscribe(@PathVariable String userId) {
+		sseService.subscribe(userId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/send/{userId}")
+	public ResponseEntity<Void> send(@PathVariable String userId, @RequestBody SseSendRequest request) {
+		sseService.sendToClient(userId, request.eventName(), request.data());
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/api/SseSendRequest.java
+++ b/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/api/SseSendRequest.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.server.internal.api;
+
+public record SseSendRequest(
+	String eventName,
+	Object data
+) {
+}

--- a/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/service/SseService.java
+++ b/server/internal/src/main/java/univ/earthbreaker/namu/server/internal/service/SseService.java
@@ -1,0 +1,39 @@
+package univ.earthbreaker.namu.server.internal.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class SseService {
+
+	private final Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+	public void subscribe(String id) {
+		long timeout = 1000L * 60; // sse emitter 연결 시간 1분
+
+		SseEmitter sseEmitter = new SseEmitter(timeout);
+		sseEmitters.put(id, sseEmitter);
+
+		sseEmitter.onCompletion(() -> sseEmitters.remove(id));
+		sseEmitter.onTimeout(sseEmitter::complete);
+		sseEmitter.onError(throwable -> sseEmitter.complete());
+	}
+
+	public void sendToClient(String id, String eventName, Object data) {
+		SseEmitter sseEmitter = sseEmitters.get(id);
+		try {
+			sseEmitter.send(
+				SseEmitter.event()
+					.id(id)
+					.name(eventName)
+					.data(data)
+			);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/server/internal/src/main/resources/application.yml
+++ b/server/internal/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+spring.application.name: internal-sse-server
+spring.profiles.active: local
+
+spring:
+  config:
+    import:
+
+  web.resources.add-mappings: false
+
+server:
+  port: 8083
+
+---
+spring.config.activate.on-profile: local
+
+
+---
+spring.config.activate.on-profile: local-dev
+
+
+---
+spring.config.activate.on-profile: dev
+
+
+---
+spring.config.activate.on-profile: staging
+
+
+---
+spring.config.activate.on-profile: live

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,6 @@ include 'event'
 
 include 'support:logging'
 
-include 'server:external'
+include 'server:external', 'server:internal'
 
 include 'tests:api-docs'

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ include 'core:domain', 'core:storage'
 
 include 'services:auth', 'services:notification'
 
-include 'clients:oauth', 'clients:aws', 'clients:image'
+include 'clients:oauth', 'clients:aws', 'clients:image', 'clients:sse'
 
 include 'event'
 


### PR DESCRIPTION
## 주요 컴포넌트

### `server:internal` 모듈

- 아주 간단한 sse Spring Boot Application 서버를 구성
- 서버를 따로 띄워서 구성

### `clients:sse` 모듈

- 서비스 어플리케이션이 타 서버 API 요청이 필요할 경우 사용하는 clients 모듈에 sse 모듈 추가
- 이를 통해 server:internal 모듈에 띄운 sse 서버와 http 통신하도록 구성


## 현재 PR로 인해 수정된 부분

<img width="664" height="539" alt="스크린샷 2025-07-21 오후 3 08 37" src="https://github.com/user-attachments/assets/4d0a0d45-27a3-4c53-b98d-7b58202cf998" />

**이미지 업로드 요청 처리 시 HTTP 스레드 점유 문제를 해소하고, 사용자에게 업로드 처리 결과를 실시간으로 전달하기 위해 SSE 기반 구조를 도입**

### 1. HTTP 스레드 점유 문제 해결을 위한 Early Return

-이미지 업로드 요청 처리에는 외부 이미지 서버와의 네트워크 I/O가 포함되며, 이 구간은 최대 10초까지 지연될 수 있음
- 기존 방식은 이 I/O 동안 API 서버의 HTTP 스레드를 점유하여, 트래픽 증가 시 서비스 장애 가능성이 있었음
- 이를 해결하기 위해 HTTP 요청을 받은 직후 Early Return하여 스레드를 즉시 반환하고, 이후 로직은 비동기 처리로 전환

### 2. 결과 알림을 위한 SSE(Server-Sent Events) 도입

- 비동기 처리 도중 이미지 업로드 실패 등 예외가 발생할 수 있으며, 이 경우 사용자가 결과를 알 수 없는 문제가 발생(혹은 게시글 페이지 조회 시 알게될 수 있음)
- 클라이언트 polling 방식도 검토하였으나, 다음과 같은 이유로 배제
    - Polling은 주기적으로 HTTP 요청을 보내기 때문에, 서비스 서버의 HTTP 스레드를 반복적으로 점유하며, 실제 이미지 업로드와 관계없는 불필요한 요청이 대량으로 생성되어 서버 리소스 낭비로 이어질 수 있음
    - 반면 SSE는 한 번의 연결로 서버의 push 메시지를 받을 수 있어, 지속 연결 기반의 효율적인 통신이 가능
- SSE 서버를 별도 Pod로 분리하여 운영하면, 메인 서비스 서버의 스레드 점유에는 영향을 주지 않으면서도 사용자에게 실시간 결과 전달이 가능할 것이라고 판단