### PR TITLE
[외부 이미지 서버로 교체 시 발생하는 문제 해결 2] HTTP 스레드 점유 문제 해결 - kafka consumer

### DIFF
--- a/app/api/build.gradle
+++ b/app/api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation project(":app:batch")
 
     implementation project(":core:domain")

--- a/app/api/build.gradle
+++ b/app/api/build.gradle
@@ -9,10 +9,22 @@ dependencies {
     implementation project(":services:notification")
 
     implementation project(":clients:oauth")
-//    implementation project(":clients:aws")
     implementation project(":clients:image")
+    implementation project(":clients:point")
 
     implementation project(":support:logging")
 
     testImplementation project(":tests:api-docs")
 }
+
+tasks.register('copyResourcesConfig', Copy) {
+    from project(':services:auth').file('src/main/resources')
+    from project(':core:storage').file('src/main/resources')
+    from project(':support:logging').file('src/main/resources')
+
+    into file("$projectDir/build/resources/main")
+
+    include '*.yml'
+}
+
+processResources.dependsOn('copyResourcesConfig')

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
@@ -52,6 +52,7 @@ public class KafkaProducerConfig {
 	}
 
 	public record RetryMessage(
+		String requestId,
 		long memberNo,
 		long missionNo,
 		String imagePathKey,
@@ -60,17 +61,18 @@ public class KafkaProducerConfig {
 		int attempt
 	) {
 		public static RetryMessage create(
+			String requestId,
 			long memberNo,
 			long missionNo,
 			String imagePathKey,
 			String postContents,
 			RetryStep retryStep
 		) {
-			return new RetryMessage(memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
+			return new RetryMessage(requestId, memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
 		}
 
 		public String getKey() {
-			return memberNo + ":" + missionNo + ":" + imagePathKey;
+			return requestId;
 		}
 	}
 

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
@@ -1,0 +1,83 @@
+package univ.earthbreaker.namu.app.api.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+	private final KafkaProperties kafkaProperties;
+
+	public KafkaProducerConfig(KafkaProperties kafkaProperties) {
+		this.kafkaProperties = kafkaProperties;
+	}
+
+	@Bean
+	public ProducerFactory<String, RetryMessage> producerFactory() {
+		Map<String, Object> props = new HashMap<>(kafkaProperties.getProperties());
+		return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new JsonSerializer<>());
+	}
+
+	@Bean
+	public KafkaTemplate<String, RetryMessage> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+
+	@Bean
+	public KafkaAdmin.NewTopics topics(
+		@Value("${kafka.topics.mission-retry.name}") String retryTopicName,
+		@Value("${kafka.topics.mission-retry.partitions}") int retryPartitions,
+		@Value("${kafka.topics.mission-retry.replicas}") int retryReplicas
+	) {
+		return new KafkaAdmin.NewTopics(
+			TopicBuilder.name(retryTopicName)
+				.partitions(retryPartitions)
+				.replicas(retryReplicas)
+				.build()
+		);
+	}
+
+	public record RetryMessage(
+		long memberNo,
+		long missionNo,
+		String imagePathKey,
+		String postContents,
+		RetryStep retryStep,
+		int attempt
+	) {
+		public static RetryMessage create(
+			long memberNo,
+			long missionNo,
+			String imagePathKey,
+			String postContents,
+			RetryStep retryStep
+		) {
+			return new RetryMessage(memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
+		}
+
+		public String getKey() {
+			return memberNo + ":" + missionNo + ":" + imagePathKey;
+		}
+	}
+
+	public enum RetryStep {
+		IMAGE_UPLOAD,
+		POINT_ISSUE,
+		;
+	}
+
+}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertificationStatusResponse.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertificationStatusResponse.java
@@ -1,0 +1,19 @@
+package univ.earthbreaker.namu.app.api.mission;
+
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyStatus;
+
+public record MissionCertificationStatusResponse(
+	String requestId,
+	long memberNo,
+	long missionNo,
+	String process
+) {
+	static MissionCertificationStatusResponse from(MissionCertifyStatus status) {
+		return new MissionCertificationStatusResponse(
+			status.getRequestId(),
+			status.getMemberNo(),
+			status.getMissionNo(),
+			status.getProcess().name()
+		);
+	}
+}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -93,11 +93,17 @@ public class MissionCertifyController {
 		String content,
 		MultipartFile missionImageFile
 	) {
+		String imagePathKey = "generate-unique";
 		try {
-			return imageManager.upload(new ImageUploadCommand());
+			return imageManager.upload(new ImageUploadCommand(
+				imagePathKey,
+				missionImageFile.getContentType(),
+				missionImageFile.getResource().contentLength(),
+				missionImageFile.getInputStream()
+			));
 		} catch (Exception e) {
 			RetryMessage retryMessage
-				= RetryMessage.create(requestId, memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
+				= RetryMessage.create(requestId, memberNo, missionNo, imagePathKey, content, RetryStep.IMAGE_UPLOAD);
 			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
@@ -105,7 +111,7 @@ public class MissionCertifyController {
 
 	private Long getReward(String requestId, Long memberNo, Long missionNo, String imagePathKey, String content) {
 		try {
-			return pointManager.issue();
+			return pointManager.issuePoint(memberNo, missionNo);
 		} catch (Exception e) {
 			RetryMessage retryMessage
 				= RetryMessage.create(requestId, memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -1,12 +1,14 @@
 package univ.earthbreaker.namu.app.api.mission;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryMessage;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryStep;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,17 +29,23 @@ import univ.earthbreaker.namu.external.image.ImageUploadCommand;
 public class MissionCertifyController {
 
 	private final ImageManager imageManager;
+	private final PointManager pointManager;
 	private final MemberMissionCertifyService missionCertifyService;
-	private final Executor executor;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+	private final String missionRetryTopic;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
+		PointManager pointManager,
 		MemberMissionCertifyService missionCertifyService,
-		Executor threadPoolExecutor
+		KafkaTemplate<String, RetryMessage> kafkaTemplate,
+		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
+		this.pointManager = pointManager;
 		this.missionCertifyService = missionCertifyService;
-		this.executor = threadPoolExecutor;
+		this.kafkaTemplate = kafkaTemplate;
+		this.missionRetryTopic = missionRetryTopic;
 	}
 
 	@AuthMapping
@@ -48,19 +56,38 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		CompletableFuture.supplyAsync(
-				() -> imageManager.upload(new ImageUploadCommand()),
-				executor
-			)
-			.exceptionally(ex -> null)
-			.thenAccept(result -> {
-				if (result != null) {
-					missionCertifyService.successMission(
-						new MissionCompleteCommand(memberNo, missionNo),
-						new CertifiedMissionPostCommand(memberNo, content, result)
-					);
-				}
-			});
+		String imagePathKey = uploadImage(missionImageFile);
+		if (imagePathKey == null) {
+			return ResponseEntity.accepted().build();
+		}
+		Long point = getReward(memberNo, missionNo, imagePathKey, content);
+		if (point == null) {
+			return ResponseEntity.accepted().build();
+		}
+		missionCertifyService.successMission(
+			new MissionCompleteCommand(memberNo, missionNo),
+			new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
+		);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	private String uploadImage(Long memberNo, Long missionNo, String content, MultipartFile missionImageFile) {
+		try {
+			return imageManager.upload(new ImageUploadCommand(missionImageFile));
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
+			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
+			return null;
+		}
+	}
+
+	private Long getReward(Long memberNo, Long missionNo, String imagePathKey, String content) {
+		try {
+			return pointManager.reward();
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
+			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
+			return null;
+		}
 	}
 }

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -1,7 +1,8 @@
 package univ.earthbreaker.namu.app.api.mission;
 
-import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryMessage;
-import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryStep;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.*;
+
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +20,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import univ.earthbreaker.namu.app.support.AuthMapping;
 import univ.earthbreaker.namu.app.support.LoginMember;
+import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyStatus;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 import univ.earthbreaker.namu.external.image.ImageManager;
 import univ.earthbreaker.namu.external.image.ImageUploadCommand;
@@ -30,6 +36,7 @@ public class MissionCertifyController {
 
 	private final ImageManager imageManager;
 	private final PointManager pointManager;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final MemberMissionCertifyService missionCertifyService;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
@@ -37,12 +44,14 @@ public class MissionCertifyController {
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
 		PointManager pointManager,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		MemberMissionCertifyService missionCertifyService,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.missionCertifyService = missionCertifyService;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
@@ -56,38 +65,58 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		String imagePathKey = uploadImage(missionImageFile);
+		String requestId = UUID.randomUUID().toString();
+		missionCertifyTrackingService.register(requestId, memberNo, missionNo);
+
+		String imagePathKey = uploadImage(requestId, memberNo, missionNo, content, missionImageFile);
 		if (imagePathKey == null) {
-			return ResponseEntity.accepted().build();
+			return ResponseEntity.accepted().body(requestId);
 		}
-		Long point = getReward(memberNo, missionNo, imagePathKey, content);
+		Long point = getReward(requestId, memberNo, missionNo, imagePathKey, content);
 		if (point == null) {
-			return ResponseEntity.accepted().build();
+			return ResponseEntity.accepted().body(requestId);
 		}
+
 		missionCertifyService.successMission(
 			new MissionCompleteCommand(memberNo, missionNo),
 			new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
 		);
+		missionCertifyTrackingService.update(requestId, MissionCertifyProcess.COMPLETED);
+
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
-	private String uploadImage(Long memberNo, Long missionNo, String content, MultipartFile missionImageFile) {
+	private String uploadImage(
+		String requestId,
+		Long memberNo,
+		Long missionNo,
+		String content,
+		MultipartFile missionImageFile
+	) {
 		try {
-			return imageManager.upload(new ImageUploadCommand(missionImageFile));
+			return imageManager.upload(new ImageUploadCommand());
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
+			RetryMessage retryMessage
+				= RetryMessage.create(requestId, memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
 			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
 	}
 
-	private Long getReward(Long memberNo, Long missionNo, String imagePathKey, String content) {
+	private Long getReward(String requestId, Long memberNo, Long missionNo, String imagePathKey, String content) {
 		try {
-			return pointManager.reward();
+			return pointManager.issue();
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
+			RetryMessage retryMessage
+				= RetryMessage.create(requestId, memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
 			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
+	}
+
+	@GetMapping("/certification/status/{requestId}")
+	public ResponseEntity<MissionCertificationStatusResponse> pollCertifyProcess(@PathVariable String requestId) {
+		MissionCertifyStatus status = missionCertifyTrackingService.retrieve(requestId);
+		return ResponseEntity.ok(MissionCertificationStatusResponse.from(status));
 	}
 }

--- a/app/api/src/main/resources/application.yml
+++ b/app/api/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       - auth.yml
 #      - clients-aws.yml
       - clients-oauth.yml
+      - classpath:kafka/kafka-producer.yml
       - notification.yml
       - storage-core.yml
       - logging.yml

--- a/app/api/src/main/resources/kafka/kafka-producer.yml
+++ b/app/api/src/main/resources/kafka/kafka-producer.yml
@@ -1,0 +1,33 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        acks: all
+        enable.idempotence: true
+        retries: 2147483647
+        max.in.flight.requests.per.connection: 1
+
+kafka:
+  topics:
+    mission-retry:
+      name: earthbreaker.namu.mission-retry
+      replicas: 3
+      partitions: 12
+
+---
+spring.config.activate.on-profile: local
+
+---
+spring.config.activate.on-profile: local-dev
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: staging
+
+---
+spring.config.activate.on-profile: live

--- a/app/kafka/build.gradle
+++ b/app/kafka/build.gradle
@@ -3,7 +3,20 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
 
     implementation project(":clients:image")
+    implementation project(":clients:point")
     implementation project(':core:domain')
+    implementation project(':core:storage')
 
     implementation project(":support:logging")
 }
+
+tasks.register('copyResourcesConfig', Copy) {
+    from project(':core:storage').file('src/main/resources')
+    from project(':support:logging').file('src/main/resources')
+
+    into file("$projectDir/build/resources/main")
+
+    include '*.yml'
+}
+
+processResources.dependsOn('copyResourcesConfig')

--- a/app/kafka/build.gradle
+++ b/app/kafka/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    implementation project(":clients:image")
+    implementation project(':core:domain')
+
+    implementation project(":support:logging")
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/ComponentScanConfig.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/ComponentScanConfig.java
@@ -1,0 +1,15 @@
+package univ.earthbreaker.namu.app.kafka;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = {
+	"univ.earthbreaker.namu.core.domain",
+	"univ.earthbreaker.namu.core.support",
+	"univ.earthbreaker.namu.core.storage",
+	"univ.earthbreaker.namu.external.image",
+	"univ.earthbreaker.namu.clients.point"
+})
+public class ComponentScanConfig {
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/NamuKafkaConsumerApplication.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/NamuKafkaConsumerApplication.java
@@ -1,0 +1,12 @@
+package univ.earthbreaker.namu.app.kafka;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NamuKafkaConsumerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(NamuKafkaConsumerApplication.class, args);
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/config/KafkaConfig.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/config/KafkaConfig.java
@@ -1,0 +1,73 @@
+package univ.earthbreaker.namu.app.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import univ.earthbreaker.namu.app.kafka.consumer.RetryMessage;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+	@Bean
+	@ConfigurationProperties("spring.kafka")
+	public KafkaProperties kafkaProperties() {
+		return new KafkaProperties();
+	}
+
+	@Bean
+	public Map<String, Object> consumerConfigs() {
+		HashMap<String, Object> props = new HashMap<>(kafkaProperties().getProperties());
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		return props;
+	}
+
+	@Bean
+	public ConsumerFactory<String, RetryMessage> consumerFactory() {
+		return new DefaultKafkaConsumerFactory<>(
+			consumerConfigs(),
+			new StringDeserializer(),
+			new JsonDeserializer<>(RetryMessage.class)
+		);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, RetryMessage> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, RetryMessage> factory
+			= new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory());
+		factory.setConcurrency(3);
+		factory.getContainerProperties().setPollTimeout(3000);
+		return factory;
+	}
+
+	/**
+	 * retry 컨슈머에서 예외 발생 시 사용할 producer 설정
+	 */
+	@Bean
+	public ProducerFactory<String, RetryMessage> producerFactory() {
+		Map<String, Object> props = new HashMap<>(kafkaProperties().getProperties());
+		return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new JsonSerializer<>());
+	}
+
+	@Bean
+	public KafkaTemplate<String, RetryMessage> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
@@ -2,6 +2,7 @@ package univ.earthbreaker.namu.app.kafka.consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -20,17 +21,20 @@ public class ImageUploadRetryService implements MissionRetryer {
 	private final PointManager pointManager;
 	private final MemberMissionCertifyService memberMissionCertifyService;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+	private final String missionRetryTopic;
 
 	public ImageUploadRetryService(
 		ImageManager imageManager,
 		PointManager pointManager,
 		MemberMissionCertifyService memberMissionCertifyService,
-		KafkaTemplate<String, RetryMessage> kafkaTemplate
+		KafkaTemplate<String, RetryMessage> kafkaTemplate,
+		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
 		this.memberMissionCertifyService = memberMissionCertifyService;
 		this.kafkaTemplate = kafkaTemplate;
+		this.missionRetryTopic = missionRetryTopic;
 	}
 
 	@Override
@@ -78,7 +82,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 
 	private void retry(String key, RetryMessage message, Exception e) {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
-			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
+			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
@@ -6,8 +6,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 import univ.earthbreaker.namu.external.image.ImageManager;
 import univ.earthbreaker.namu.external.image.ImageUploadCommand;
@@ -20,6 +23,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 	private final ImageManager imageManager;
 	private final PointManager pointManager;
 	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
 
@@ -27,12 +31,14 @@ public class ImageUploadRetryService implements MissionRetryer {
 		ImageManager imageManager,
 		PointManager pointManager,
 		MemberMissionCertifyService memberMissionCertifyService,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
 		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
 	}
@@ -57,6 +63,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
 			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
 		);
+		missionCertifyTrackingService.update(key, MissionCertifyProcess.COMPLETED);
 	}
 
 	private boolean handleImageUploadRetry(String key, RetryMessage message) {
@@ -73,7 +80,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 
 	private Long handlePointRetry(String key, RetryMessage message) {
 		try {
-			return pointManager.reward();
+			return pointManager.issue();
 		} catch (Exception e) {
 			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
 			return null;
@@ -84,6 +91,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
 			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
+			missionCertifyTrackingService.update(key, MissionCertifyProcess.FAILED);
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}
 	}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
@@ -1,0 +1,86 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
+import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
+import univ.earthbreaker.namu.external.image.ImageManager;
+import univ.earthbreaker.namu.external.image.ImageUploadCommand;
+
+@Service
+public class ImageUploadRetryService implements MissionRetryer {
+
+	private static final Logger log = LoggerFactory.getLogger(ImageUploadRetryService.class);
+
+	private final ImageManager imageManager;
+	private final PointManager pointManager;
+	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+
+	public ImageUploadRetryService(
+		ImageManager imageManager,
+		PointManager pointManager,
+		MemberMissionCertifyService memberMissionCertifyService,
+		KafkaTemplate<String, RetryMessage> kafkaTemplate
+	) {
+		this.imageManager = imageManager;
+		this.pointManager = pointManager;
+		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	@Override
+	public RetryStep supportStep() {
+		return RetryStep.IMAGE_UPLOAD;
+	}
+
+	@Override
+	public void process(String key, RetryMessage message) {
+		if (!handleImageUploadRetry(key, message)) { // 이미지 업로드 실패 시 메서드 종료
+			log.info("Image upload failed for key: {}, record message : {}", key, message);
+			return;
+		}
+		Long point = handlePointRetry(key, message);
+		if (point == null) {  // 포인트 발급 실패 시 메서드 종료
+			log.info("Point for upload failed for key: {}, record message : {}", key, message);
+			return;
+		}
+		memberMissionCertifyService.successMission(
+			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
+			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
+		);
+	}
+
+	private boolean handleImageUploadRetry(String key, RetryMessage message) {
+		try {
+			if (imageManager.retrieve(message.imagePathKey()) == null) {
+				imageManager.upload(new ImageUploadCommand());
+			}
+			return true;
+		} catch (Exception e) {
+			retry(key, message.toNext(RetryStep.IMAGE_UPLOAD), e);
+			return false;
+		}
+	}
+
+	private Long handlePointRetry(String key, RetryMessage message) {
+		try {
+			return pointManager.reward();
+		} catch (Exception e) {
+			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
+			return null;
+		}
+	}
+
+	private void retry(String key, RetryMessage message, Exception e) {
+		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
+		} else {
+			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
+		}
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
@@ -80,7 +80,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 
 	private Long handlePointRetry(String key, RetryMessage message) {
 		try {
-			return pointManager.issue();
+			return pointManager.issuePoint(message.memberNo(), message.missionNo());
 		} catch (Exception e) {
 			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
 			return null;

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
@@ -1,0 +1,95 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
+import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
+import univ.earthbreaker.namu.external.image.ImageManager;
+import univ.earthbreaker.namu.external.image.ImageUploadCommand;
+
+@Component
+public class MissionRetryConsumer {
+
+	private final ImageManager imageManager;
+	private final PointManager pointManager;
+	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+
+	public MissionRetryConsumer(
+		ImageManager imageManager,
+		PointManager pointManager,
+		MemberMissionCertifyService memberMissionCertifyService,
+		KafkaTemplate<String, RetryMessage> kafkaTemplate
+	) {
+		this.imageManager = imageManager;
+		this.pointManager = pointManager;
+		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	@KafkaListener(topics = "earthbreaker.namu.mission-retry", groupId = "${spring.kafka.consumer.group-id}")
+	public void handleRetry(ConsumerRecord<String, RetryMessage> recordEvent) {
+		RetryMessage message = recordEvent.value();
+		Long point;
+		switch (message.retryStep()) {
+			case IMAGE_UPLOAD:
+				if (!handleImageUploadRetry(recordEvent.key(), message)) { // 이미지 업로드 실패 시 메서드 종료
+					return;
+				}
+				point = handlePointRetry(recordEvent.key(), message);
+				if (point == null) {  // 포인트 발급 실패 시 메서드 종료
+					return;
+				}
+				memberMissionCertifyService.successMission(
+					new MissionCompleteCommand(message.memberNo(), message.missionNo()),
+					new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey()),
+					point
+				);
+				break;
+			case POINT_ISSUE:
+				point = handlePointRetry(recordEvent.key(), message);
+				if (point == null) { // 포인트 발급 실패 시 메서드 종료
+					return;
+				}
+				memberMissionCertifyService.successMission(
+					new MissionCompleteCommand(message.memberNo(), message.missionNo()),
+					new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey()),
+					point
+				);
+				break;
+			default:
+				break;
+		}
+	}
+
+	private boolean handleImageUploadRetry(String key, RetryMessage message) {
+		try {
+			if (imageManager.retrieve(message.imagePathKey()) == null) {
+				imageManager.upload(new ImageUploadCommand());
+			}
+			return true;
+		} catch (Exception e) {
+			retry(key, message.toNext(RetryStep.IMAGE_UPLOAD));
+			return false;
+		}
+	}
+
+	private Long handlePointRetry(String key, RetryMessage message) {
+		try {
+			return pointManager.reword();
+		} catch (Exception e) {
+			retry(key, message.toNext(RetryStep.POINT_ISSUE));
+			return null;
+		}
+	}
+
+	private void retry(String key, RetryMessage message) {
+		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
+		}
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
@@ -13,7 +13,7 @@ public class MissionRetryConsumer {
 		this.missionRetryerFactory = missionRetryerFactory;
 	}
 
-	@KafkaListener(topics = {"earthbreaker.namu.mission-retry"}, groupId = "${spring.kafka.consumer.group-id}")
+	@KafkaListener(topics = {"${kafka.topics.mission-retry.name}"}, groupId = "${spring.kafka.consumer.group-id}")
 	public void handleRetry(ConsumerRecord<String, RetryMessage> recordEvent) {
 		RetryMessage message = recordEvent.value();
 		MissionRetryer missionRetryer = missionRetryerFactory.get(message.retryStep());

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryConsumer.java
@@ -2,94 +2,21 @@ package univ.earthbreaker.namu.app.kafka.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
-
-import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
-import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
-import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
-import univ.earthbreaker.namu.external.image.ImageManager;
-import univ.earthbreaker.namu.external.image.ImageUploadCommand;
 
 @Component
 public class MissionRetryConsumer {
 
-	private final ImageManager imageManager;
-	private final PointManager pointManager;
-	private final MemberMissionCertifyService memberMissionCertifyService;
-	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+	private final MissionRetryerFactory missionRetryerFactory;
 
-	public MissionRetryConsumer(
-		ImageManager imageManager,
-		PointManager pointManager,
-		MemberMissionCertifyService memberMissionCertifyService,
-		KafkaTemplate<String, RetryMessage> kafkaTemplate
-	) {
-		this.imageManager = imageManager;
-		this.pointManager = pointManager;
-		this.memberMissionCertifyService = memberMissionCertifyService;
-		this.kafkaTemplate = kafkaTemplate;
+	public MissionRetryConsumer(MissionRetryerFactory missionRetryerFactory) {
+		this.missionRetryerFactory = missionRetryerFactory;
 	}
 
-	@KafkaListener(topics = "earthbreaker.namu.mission-retry", groupId = "${spring.kafka.consumer.group-id}")
+	@KafkaListener(topics = {"earthbreaker.namu.mission-retry"}, groupId = "${spring.kafka.consumer.group-id}")
 	public void handleRetry(ConsumerRecord<String, RetryMessage> recordEvent) {
 		RetryMessage message = recordEvent.value();
-		Long point;
-		switch (message.retryStep()) {
-			case IMAGE_UPLOAD:
-				if (!handleImageUploadRetry(recordEvent.key(), message)) { // 이미지 업로드 실패 시 메서드 종료
-					return;
-				}
-				point = handlePointRetry(recordEvent.key(), message);
-				if (point == null) {  // 포인트 발급 실패 시 메서드 종료
-					return;
-				}
-				memberMissionCertifyService.successMission(
-					new MissionCompleteCommand(message.memberNo(), message.missionNo()),
-					new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey()),
-					point
-				);
-				break;
-			case POINT_ISSUE:
-				point = handlePointRetry(recordEvent.key(), message);
-				if (point == null) { // 포인트 발급 실패 시 메서드 종료
-					return;
-				}
-				memberMissionCertifyService.successMission(
-					new MissionCompleteCommand(message.memberNo(), message.missionNo()),
-					new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey()),
-					point
-				);
-				break;
-			default:
-				break;
-		}
-	}
-
-	private boolean handleImageUploadRetry(String key, RetryMessage message) {
-		try {
-			if (imageManager.retrieve(message.imagePathKey()) == null) {
-				imageManager.upload(new ImageUploadCommand());
-			}
-			return true;
-		} catch (Exception e) {
-			retry(key, message.toNext(RetryStep.IMAGE_UPLOAD));
-			return false;
-		}
-	}
-
-	private Long handlePointRetry(String key, RetryMessage message) {
-		try {
-			return pointManager.reword();
-		} catch (Exception e) {
-			retry(key, message.toNext(RetryStep.POINT_ISSUE));
-			return null;
-		}
-	}
-
-	private void retry(String key, RetryMessage message) {
-		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
-			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
-		}
+		MissionRetryer missionRetryer = missionRetryerFactory.get(message.retryStep());
+		missionRetryer.process(recordEvent.key(), message);
 	}
 }

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryer.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryer.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+public interface MissionRetryer {
+
+	RetryStep supportStep();
+
+	void process(String key, RetryMessage message);
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryerFactory.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/MissionRetryerFactory.java
@@ -1,0 +1,22 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissionRetryerFactory {
+
+	private final Map<RetryStep, MissionRetryer> retryers;
+
+	public MissionRetryerFactory(List<MissionRetryer> retryers) {
+		this.retryers = retryers.stream()
+			.collect(Collectors.toMap(MissionRetryer::supportStep, retryer -> retryer));
+	}
+
+	public MissionRetryer get(RetryStep retryStep) {
+		return retryers.get(retryStep);
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
@@ -59,7 +59,7 @@ public class PointIssueRetryService implements MissionRetryer {
 
 	private Long handlePointRetry(String key, RetryMessage message) {
 		try {
-			return pointManager.issue();
+			return pointManager.issuePoint();
 		} catch (Exception e) {
 			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
 			return null;

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
@@ -2,6 +2,7 @@ package univ.earthbreaker.namu.app.kafka.consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -17,15 +18,18 @@ public class PointIssueRetryService implements MissionRetryer {
 	private final MemberMissionCertifyService memberMissionCertifyService;
 	private final PointManager pointManager;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+	private final String missionRetryTopic;
 
 	public PointIssueRetryService(
 		MemberMissionCertifyService memberMissionCertifyService,
 		PointManager pointManager,
-		KafkaTemplate<String, RetryMessage> kafkaTemplate
+		KafkaTemplate<String, RetryMessage> kafkaTemplate,
+		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.memberMissionCertifyService = memberMissionCertifyService;
 		this.pointManager = pointManager;
 		this.kafkaTemplate = kafkaTemplate;
+		this.missionRetryTopic = missionRetryTopic;
 	}
 
 	@Override
@@ -57,7 +61,7 @@ public class PointIssueRetryService implements MissionRetryer {
 
 	private void retry(String key, RetryMessage message, Exception e) {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
-			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
+			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
@@ -6,8 +6,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 
 @Service
@@ -16,17 +19,20 @@ public class PointIssueRetryService implements MissionRetryer {
 	private static final Logger log = LoggerFactory.getLogger(PointIssueRetryService.class);
 
 	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final PointManager pointManager;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
 
 	public PointIssueRetryService(
 		MemberMissionCertifyService memberMissionCertifyService,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		PointManager pointManager,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.pointManager = pointManager;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
@@ -48,11 +54,12 @@ public class PointIssueRetryService implements MissionRetryer {
 			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
 			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
 		);
+		missionCertifyTrackingService.update(key, MissionCertifyProcess.COMPLETED);
 	}
 
 	private Long handlePointRetry(String key, RetryMessage message) {
 		try {
-			return pointManager.reward();
+			return pointManager.issue();
 		} catch (Exception e) {
 			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
 			return null;
@@ -63,6 +70,7 @@ public class PointIssueRetryService implements MissionRetryer {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
 			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
+			missionCertifyTrackingService.update(key, MissionCertifyProcess.FAILED);
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}
 	}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
@@ -1,0 +1,65 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
+import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
+
+@Service
+public class PointIssueRetryService implements MissionRetryer {
+
+	private static final Logger log = LoggerFactory.getLogger(PointIssueRetryService.class);
+
+	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final PointManager pointManager;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+
+	public PointIssueRetryService(
+		MemberMissionCertifyService memberMissionCertifyService,
+		PointManager pointManager,
+		KafkaTemplate<String, RetryMessage> kafkaTemplate
+	) {
+		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.pointManager = pointManager;
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	@Override
+	public RetryStep supportStep() {
+		return RetryStep.POINT_ISSUE;
+	}
+
+	@Override
+	public void process(String key, RetryMessage message) {
+		Long point = handlePointRetry(key, message);
+		if (point == null) { // 포인트 발급 실패 시 메서드 종료
+			log.info("Point for upload failed for key: {}, record message : {}", key, message);
+			return;
+		}
+		memberMissionCertifyService.successMission(
+			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
+			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
+		);
+	}
+
+	private Long handlePointRetry(String key, RetryMessage message) {
+		try {
+			return pointManager.reward();
+		} catch (Exception e) {
+			retry(key, message.toNext(RetryStep.POINT_ISSUE), e);
+			return null;
+		}
+	}
+
+	private void retry(String key, RetryMessage message, Exception e) {
+		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", key, message);
+		} else {
+			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
+		}
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
@@ -1,6 +1,7 @@
 package univ.earthbreaker.namu.app.kafka.consumer;
 
 public record RetryMessage(
+	String requestId,
 	long memberNo,
 	long missionNo,
 	String imagePathKey,
@@ -12,6 +13,7 @@ public record RetryMessage(
 
 	public RetryMessage toNext(RetryStep retryStep) {
 		return new RetryMessage(
+			requestId,
 			memberNo,
 			missionNo,
 			imagePathKey,

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
@@ -1,0 +1,23 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+public record RetryMessage(
+	long memberNo,
+	long missionNo,
+	String imagePathKey,
+	String postContents,
+	RetryStep retryStep,
+	int attempt
+) {
+	static final int MAX_RETRY_ATTEMPTS = 3;
+
+	public RetryMessage toNext(RetryStep retryStep) {
+		return new RetryMessage(
+			memberNo,
+			missionNo,
+			imagePathKey,
+			postContents,
+			retryStep,
+			attempt + 1
+		);
+	}
+}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryStep.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryStep.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.app.kafka.consumer;
+
+public enum RetryStep {
+	IMAGE_UPLOAD,
+	POINT_ISSUE,
+	;
+}

--- a/app/kafka/src/main/resources/application.yml
+++ b/app/kafka/src/main/resources/application.yml
@@ -8,11 +8,18 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: mission-retry-consumer
-      enable-auto-commit: true
-      auto-commit-interval: 5000
-      auto-offset-reset: latest
-      max-poll-records: 10
-      heartbeat-interval: 3000
+      properties:
+        session.timeout.ms: 10000
+        heartbeat.interval.ms: 3000
+        request.timeout.ms: 3000
+
+        max.poll.interval.ms: 300000
+        max.poll.records: 10
+
+        enable.auto.commit: true
+        auto.commit.interval: 1000
+
+        auto.offset.reset: latest
 
 ---
 spring.config.activate.on-profile: local

--- a/app/kafka/src/main/resources/application.yml
+++ b/app/kafka/src/main/resources/application.yml
@@ -3,7 +3,10 @@ spring.profiles.active: local
 
 spring:
   config:
-    import: classpath:kafka-topic.yml
+    import:
+      - classpath:kafka-topic.yml
+      - storage-core.yml
+      - logging.yml
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
@@ -20,6 +23,9 @@ spring:
         auto.commit.interval: 1000
 
         auto.offset.reset: latest
+
+server:
+  port: 8085
 
 ---
 spring.config.activate.on-profile: local

--- a/app/kafka/src/main/resources/application.yml
+++ b/app/kafka/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring.application.name: kafka-consumer-app
+spring.profiles.active: local
+
+spring:
+  config:
+    import: classpath:kafka-topic.yml
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: mission-retry-consumer
+      enable-auto-commit: true
+      auto-commit-interval: 5000
+      auto-offset-reset: latest
+      max-poll-records: 10
+      heartbeat-interval: 3000
+
+---
+spring.config.activate.on-profile: local
+
+---
+spring.config.activate.on-profile: dev

--- a/app/kafka/src/main/resources/kafka-topic.yml
+++ b/app/kafka/src/main/resources/kafka-topic.yml
@@ -1,0 +1,4 @@
+kafka:
+  topics:
+    mission-retry:
+      name: earthbreaker.namu.mission-retry

--- a/clients/image/build.gradle
+++ b/clients/image/build.gradle
@@ -5,4 +5,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.github.openfeign:feign-hc5'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    implementation project(':server:external')
 }

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
@@ -2,8 +2,15 @@ package univ.earthbreaker.namu.external.image;
 
 import org.springframework.stereotype.Component;
 
+import univ.earthbreaker.namu.server.external.api.image.ImageRequest;
+import univ.earthbreaker.namu.server.external.api.image.ImageUploadRequest;
+import univ.earthbreaker.namu.server.external.api.image.ObjectMetaData;
+import univ.earthbreaker.namu.server.external.exception.ExternalImageServerException;
+
 @Component
 public class ExternalImageManager implements ImageManager {
+
+	private static final String BUCKET_NAME = "my-bucket";
 
 	private final ImageApiCaller imageApiCaller;
 
@@ -13,18 +20,29 @@ public class ExternalImageManager implements ImageManager {
 
 	@Override
 	public String upload(ImageUploadCommand command) {
-		ExternalImageResult response = imageApiCaller.uploadImage();
-		return response.message();
+		ObjectMetaData objectMetadata = new ObjectMetaData();
+		objectMetadata.setContentType(command.contentType());
+		objectMetadata.setContentLength(command.contentLength());
+
+		String imagePathKey = command.imagePathKey();
+		try {
+			imageApiCaller.uploadImage(new ImageUploadRequest(BUCKET_NAME, imagePathKey, command.inputStream(), objectMetadata));
+		} catch (ExternalImageServerException e) {
+			throw ImageServerServerException.uploadFail(e.getMessage(), imagePathKey);
+		}
+		return imagePathKey;
 	}
 
 	@Override
 	public String retrieve(String imagePathKey) {
-		ExternalImageResult response = imageApiCaller.getImage();
+		ImageRequest request = new ImageRequest(BUCKET_NAME, imagePathKey);
+		ExternalImageResult response = imageApiCaller.getImage(request);
 		return response.data().toString();
 	}
 
 	@Override
 	public void delete(String imagePathKey) {
-		imageApiCaller.deleteImage();
+		ImageRequest request = new ImageRequest(BUCKET_NAME, imagePathKey);
+		imageApiCaller.deleteImage(request);
 	}
 }

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ExternalImageManager.java
@@ -18,6 +18,12 @@ public class ExternalImageManager implements ImageManager {
 	}
 
 	@Override
+	public String retrieve(String imagePathKey) {
+		ExternalImageResult response = imageApiCaller.getImage();
+		return response.data().toString();
+	}
+
+	@Override
 	public void delete(String imagePathKey) {
 		imageApiCaller.deleteImage();
 	}

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 	name = "imageApiCaller",
 	url = "http://localhost:8082/external/image",
 	configuration = ImageFeignConfiguration.class)
-interface ImageApiCaller {
+public interface ImageApiCaller {
 
 	@PostMapping(value = "/upload")
 	ExternalImageResult uploadImage();

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageApiCaller.java
@@ -3,6 +3,10 @@ package univ.earthbreaker.namu.external.image;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import univ.earthbreaker.namu.server.external.api.image.ImageRequest;
+import univ.earthbreaker.namu.server.external.api.image.ImageUploadRequest;
 
 @FeignClient(
 	name = "imageApiCaller",
@@ -11,11 +15,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 public interface ImageApiCaller {
 
 	@PostMapping(value = "/upload")
-	ExternalImageResult uploadImage();
+	ExternalImageResult uploadImage(@RequestBody ImageUploadRequest request);
 
 	@PostMapping(value = "/delete")
-	ExternalImageResult deleteImage();
+	ExternalImageResult deleteImage(@RequestBody ImageRequest request);
 
 	@GetMapping
-	ExternalImageResult getImage();
+	ExternalImageResult getImage(@RequestBody ImageRequest request);
 }

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageManager.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageManager.java
@@ -4,5 +4,7 @@ public interface ImageManager {
 
 	String upload(ImageUploadCommand command);
 
+	String retrieve(String imagePathKey);
+
 	void delete(String imagePathKey);
 }

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageServerServerException.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageServerServerException.java
@@ -5,4 +5,8 @@ class ImageServerServerException extends RuntimeException {
 	public ImageServerServerException(String message) {
 		super(message);
 	}
+
+	static ImageServerServerException uploadFail(String message, String key) {
+		return new ImageServerServerException(message + ": " + key);
+	}
 }

--- a/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageUploadCommand.java
+++ b/clients/image/src/main/java/univ/earthbreaker/namu/external/image/ImageUploadCommand.java
@@ -1,4 +1,11 @@
 package univ.earthbreaker.namu.external.image;
 
-public record ImageUploadCommand() {
+import java.io.InputStream;
+
+public record ImageUploadCommand(
+	String imagePathKey,
+	String contentType,
+	long contentLength,
+	InputStream inputStream
+) {
 }

--- a/clients/point/build.gradle
+++ b/clients/point/build.gradle
@@ -4,4 +4,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.github.openfeign:feign-hc5'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    implementation project(':server:external')
 }

--- a/clients/point/build.gradle
+++ b/clients/point/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compileOnly("org.springframework:spring-context")
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-hc5'
+    implementation 'io.github.openfeign:feign-micrometer'
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ExternalPointManager.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ExternalPointManager.java
@@ -1,0 +1,28 @@
+package univ.earthbreaker.namu.clients.point;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Component;
+
+import univ.earthbreaker.namu.server.external.api.point.PointIssueRequest;
+
+@Component
+public class ExternalPointManager implements PointManager {
+
+	private final PointApiCaller pointApiCaller;
+
+	public ExternalPointManager(PointApiCaller pointApiCaller) {
+		this.pointApiCaller = pointApiCaller;
+	}
+
+	@Override
+	public Long issuePoint(long memberNo, long missionNo) {
+		PointIssueRequest request = new PointIssueRequest(memberNo, missionNo, Instant.now().toEpochMilli());
+		try {
+			ExternalPointResult result = pointApiCaller.issuePoint(null, request);
+			return result.point();
+		} catch (Exception e) {
+			throw new PointServerServerException(e.getMessage());
+		}
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ExternalPointResult.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ExternalPointResult.java
@@ -1,0 +1,4 @@
+package univ.earthbreaker.namu.clients.point;
+
+public record ExternalPointResult(int code, String message, Long point) {
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointApiCaller.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointApiCaller.java
@@ -1,0 +1,22 @@
+package univ.earthbreaker.namu.clients.point;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import univ.earthbreaker.namu.server.external.Headers;
+import univ.earthbreaker.namu.server.external.api.point.PointIssueRequest;
+
+@FeignClient(
+	name = "pointApiCaller",
+	url = "http://localhost:8082/external/point",
+	configuration = PointFeignConfiguration.class)
+public interface PointApiCaller {
+
+	@PostMapping(value = "/issue")
+	ExternalPointResult issuePoint(
+		@RequestHeader(value = Headers.IDEMPOTENCY_KEY, required = false) String idempotencyKey,
+		@RequestBody PointIssueRequest request
+	);
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointFeignConfiguration.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointFeignConfiguration.java
@@ -1,0 +1,34 @@
+package univ.earthbreaker.namu.clients.point;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.Request;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
+
+@EnableFeignClients
+@Configuration
+class PointFeignConfiguration {
+
+	private static final long CONNECTION_TIMEOUT = 1_000;
+	private static final long READ_TIMEOUT = 5_000;
+
+	@Bean(name = "feignRequestTimeoutOptions")
+	Request.Options requestOptions() {
+		return new Request.Options(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS, READ_TIMEOUT, TimeUnit.MILLISECONDS, false);
+	}
+
+	@Bean(name = "pointRetryer")
+	public Retryer retryer() {
+		return Retryer.NEVER_RETRY;
+	}
+
+	@Bean(name = "pointErrorDecoder")
+	ErrorDecoder errorDecoder() {
+		return new PointFeignExceptionDecoder();
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointFeignExceptionDecoder.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointFeignExceptionDecoder.java
@@ -1,0 +1,20 @@
+package univ.earthbreaker.namu.clients.point;
+
+import org.springframework.http.HttpStatus;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+class PointFeignExceptionDecoder implements ErrorDecoder {
+
+	@Override
+	public Exception decode(String methodKey, Response response) {
+		HttpStatus status = HttpStatus.resolve(response.status());
+		if (status == HttpStatus.BAD_REQUEST) {
+			throw new PointServerServerException(
+				String.format("[포인트 서버 API BAD_REQUEST] %s : %s", methodKey, response.reason()));
+		}
+		throw new PointServerServerException(
+			String.format("[포인트 서버 API SERVER_ERROR] %s : %s", methodKey, response.reason()));
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointManager.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointManager.java
@@ -1,5 +1,5 @@
 package univ.earthbreaker.namu.clients.point;
 
 public interface PointManager {
-	Long issue();
+	Long issuePoint(long memberNo, long missionNo);
 }

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointManager.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointManager.java
@@ -1,0 +1,5 @@
+package univ.earthbreaker.namu.clients.point;
+
+public interface PointManager {
+	Long issue();
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerBadRequestException.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerBadRequestException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.clients.point;
+
+class PointServerBadRequestException extends RuntimeException {
+
+	public PointServerBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerException.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerException.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.clients.point;
+
+public class PointServerException extends RuntimeException {
+	public PointServerException(String message) {
+		super(message);
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerException.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerException.java
@@ -1,7 +1,0 @@
-package univ.earthbreaker.namu.clients.point;
-
-public class PointServerException extends RuntimeException {
-	public PointServerException(String message) {
-		super(message);
-	}
-}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerServerException.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/PointServerServerException.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.clients.point;
+
+class PointServerServerException extends RuntimeException {
+
+	public PointServerServerException(String message) {
+		super(message);
+	}
+}

--- a/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ZzaptarbucksRandomLatencyPointManager.java
+++ b/clients/point/src/main/java/univ/earthbreaker/namu/clients/point/ZzaptarbucksRandomLatencyPointManager.java
@@ -1,0 +1,68 @@
+package univ.earthbreaker.namu.clients.point;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZzaptarbucksRandomLatencyPointManager implements PointManager {
+
+	private static final AtomicLong POINT = new AtomicLong(10_000_000) ;
+	private static final Random RANDOM = new Random();
+
+	private static final long FIXED_REWARD_POINT = 10;
+	private static final int MIN_DELAY_MS = 100; // 최소 지연 시간
+	private static final int MAX_DELAY_MS = 3_000; // 최대 지연 시간
+	private static final double EXCEPTION_PROBABILITY = 0.01; // 예외 발생 확률 (1%)
+
+	/**
+	 * 총 1천만 포인트에 대해서, 사용자 별로 10포인트 씩 제공
+	 * @throws IllegalStateException : 준비되니 1천만 포인트가 모두 사라진 경우 예외 발생
+	 * @return 10포인트
+	 */
+	@Override
+	public Long issue() {
+		int delay = getDelay();
+		delaySimulation(delay);
+		invokeException();
+
+		long current = POINT.get();
+		long next = current - FIXED_REWARD_POINT;
+
+		if (next < 0) {
+			throw new IllegalStateException("The point has been reached");
+		}
+
+		POINT.compareAndSet(current, next);
+		return FIXED_REWARD_POINT; // 지급한 포인트만 반환
+	}
+
+	/**
+	 * @return 랜덤한 지연 시간 (100ms ~ 3000ms)
+	 */
+	private int getDelay() {
+		return RANDOM.nextInt(MAX_DELAY_MS - MIN_DELAY_MS + 1) + MIN_DELAY_MS;
+	}
+
+	/**
+	 * 지연 시뮬레이션
+	 * @param delay 지연시간
+	 */
+	private void delaySimulation(int delay) {
+		try {
+			Thread.sleep(delay);
+		} catch (InterruptedException e) {
+			throw new PointServerException(e.getMessage());
+		}
+	}
+
+	/**
+	 * 1% 확률로 ReadTimeout Exception 실패 발생시키기
+	 */
+	private void invokeException() {
+		if (RANDOM.nextDouble() < EXCEPTION_PROBABILITY) {
+			throw new PointServerException("Read Timeout Exception");
+		}
+	}
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/CertifiedMissionPostCommand.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/CertifiedMissionPostCommand.java
@@ -9,12 +9,14 @@ public class CertifiedMissionPostCommand extends SelfValidating<CertifiedMission
 	private final @NotNull Long memberNo;
 	private final @NotNull @NotBlank String content;
 	private final @NotBlank String imagePathKey;
+	private final @NotNull Long point;
 
-	public CertifiedMissionPostCommand(Long memberNo, String content, String imagePathKey) {
+	public CertifiedMissionPostCommand(Long memberNo, String content, String imagePathKey, Long point) {
 		this.memberNo = memberNo;
 		this.content = content;
 		this.imagePathKey = imagePathKey;
-		this.validateSelf("memberNo 가 null 이거나, content, imagePathKey 가 null 또는 공백일 수 없습니다");
+		this.point = point;
+		this.validateSelf("memberNo 가 null 이거나, content, imagePathKey, point 가 null 또는 공백일 수 없습니다");
 	}
 
 	public Long getMemberNo() {
@@ -27,5 +29,9 @@ public class CertifiedMissionPostCommand extends SelfValidating<CertifiedMission
 
 	public String getImagePathKey() {
 		return imagePathKey;
+	}
+
+	public Long getPoint() {
+		return point;
 	}
 }

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyProcess.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyProcess.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+public enum MissionCertifyProcess {
+	PENDING,
+	COMPLETED,
+	FAILED,
+	;
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyStatus.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyStatus.java
@@ -1,0 +1,32 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+public class MissionCertifyStatus {
+
+	private final String requestId;
+	private final long memberNo;
+	private final long missionNo;
+	private final MissionCertifyProcess process;
+
+	public MissionCertifyStatus(String requestId, long memberNo, long missionNo, MissionCertifyProcess process) {
+		this.requestId = requestId;
+		this.memberNo = memberNo;
+		this.missionNo = missionNo;
+		this.process = process;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public long getMemberNo() {
+		return memberNo;
+	}
+
+	public long getMissionNo() {
+		return missionNo;
+	}
+
+	public MissionCertifyProcess getProcess() {
+		return process;
+	}
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyTrackingService.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyTrackingService.java
@@ -1,0 +1,38 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+import org.springframework.stereotype.Service;
+
+import univ.earthbreaker.namu.core.support.tx.TransactionHandler;
+
+@Service
+public class MissionCertifyTrackingService {
+
+	private final MissionCertifyStatusRepository missionCertifyStatusRepository;
+	private final TransactionHandler transactionHandler;
+
+	public MissionCertifyTrackingService(
+		MissionCertifyStatusRepository missionCertifyStatusRepository,
+		TransactionHandler transactionHandler
+	) {
+		this.missionCertifyStatusRepository = missionCertifyStatusRepository;
+		this.transactionHandler = transactionHandler;
+	}
+
+	public void register(String requestId, long memberNo, long missionNo) {
+		transactionHandler.execute(() -> {
+			missionCertifyStatusRepository.register(requestId, memberNo, missionNo);
+			return null;
+		});
+	}
+
+	public void update(String requestId, MissionCertifyProcess process) {
+		transactionHandler.execute(() -> {
+			missionCertifyStatusRepository.update(requestId, process);
+			return null;
+		});
+	}
+
+	public MissionCertifyStatus retrieve(String requestId) {
+		return missionCertifyStatusRepository.retrieve(requestId);
+	}
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/support/NamuTransactionHandlerAdapter.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/support/NamuTransactionHandlerAdapter.java
@@ -5,11 +5,11 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
-class TransactionHandlerAdapter implements TransactionHandler {
+class NamuTransactionHandlerAdapter implements TransactionHandler {
 
 	private final TransactionTemplate transactionTemplate;
 
-	public TransactionHandlerAdapter(TransactionTemplate transactionTemplate) {
+	public NamuTransactionHandlerAdapter(TransactionTemplate transactionTemplate) {
 		this.transactionTemplate = transactionTemplate;
 	}
 

--- a/infra/kafka/docker-compose.kafka.local.yml
+++ b/infra/kafka/docker-compose.kafka.local.yml
@@ -1,0 +1,123 @@
+#version: '3'
+#services:
+#  zookeeper:
+#    image: wurstmeister/zookeeper
+#    container_name: zookeeper
+#    ports:
+#      - "2181:2181"
+#    # Mac M1 chip 사용 시 아래 platform 추가
+#    platform: linux/amd64
+#
+#  kafka:
+#    image: wurstmeister/kafka
+#    container_name: kafka
+#    ports:
+#      - "9092:9092"
+#    environment:
+#      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+#      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+#      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+#      KAFKA_ADVERTISED_PORT: 9092
+#      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+#      KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+#    depends_on:
+#      - zookeeper
+
+services:
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
+  zoo2:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo2
+    container_name: zoo2
+    ports:
+      - "2182:2182"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2182
+      ZOOKEEPER_SERVER_ID: 2
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
+  zoo3:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo3
+    container_name: zoo3
+    ports:
+      - "2183:2183"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2183
+      ZOOKEEPER_SERVER_ID: 3
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
+
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  kafka2:
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka2
+    container_name: kafka2
+    ports:
+      - "9093:9093"
+      - "29093:29093"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093,DOCKER://host.docker.internal:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 2
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  kafka3:
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka3
+    container_name: kafka3
+    ports:
+      - "9094:9094"
+      - "29094:29094"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094,DOCKER://host.docker.internal:29094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 3
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3

--- a/infra/kafka/kafka.local.start.sh
+++ b/infra/kafka/kafka.local.start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e  # 오류 발생 시 스크립트 중지
+
+echo "Starting Local Kafka..."
+docker-compose -f docker-compose.kafka.local.yml up -d

--- a/infra/kafka/kafka.local.terminate.sh
+++ b/infra/kafka/kafka.local.terminate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e  # 오류 발생 시 스크립트 중지
+
+echo "Terminate Local Kafka..."
+docker-compose docker down

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/Headers.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/Headers.java
@@ -1,0 +1,19 @@
+package univ.earthbreaker.namu.server.external;
+
+public interface Headers {
+
+	String CACHE_CONTROL = "Cache-Control";
+	String CONTENT_DISPOSITION = "Content-Disposition";
+	String CONTENT_ENCODING = "Content-Encoding";
+	String CONTENT_LENGTH = "Content-Length";
+	String CONTENT_RANGE = "Content-Range";
+	String CONTENT_MD5 = "Content-MD5";
+	String CONTENT_TYPE = "Content-Type";
+	String CONTENT_LANGUAGE = "Content-Language";
+	String DATE = "Date";
+	String ETAG = "ETag";
+	String LAST_MODIFIED = "Last-Modified";
+	String SERVER = "Server";
+	String CONNECTION = "Connection";
+	String IDEMPOTENCY_KEY = "Idempotency-Key";
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageApiServer.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageApiServer.java
@@ -1,9 +1,10 @@
-package univ.earthbreaker.namu.server.external.api;
+package univ.earthbreaker.namu.server.external.api.image;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,20 +19,21 @@ public class ExternalImageApiServer {
 	}
 
 	@PostMapping("/upload")
-	public ResponseEntity<ExternalImageResponse> uploadSuccess() {
-		String resultMessage = randomLatencyImageManager.uploadImage("", "");
+	public ResponseEntity<ExternalImageResponse> uploadSuccess(@RequestBody ImageUploadRequest request) {
+		String sampleImageData = String.format("%s:%s:%s", request.bucketName(), request.key(), request.objectMetaData().getContentType());
+		String resultMessage = randomLatencyImageManager.uploadImage(request.key(), sampleImageData);
 		return ResponseEntity.ok(new ExternalImageResponse(HttpStatus.OK.value(), resultMessage, null));
 	}
 
 	@PostMapping("/delete")
-	public ResponseEntity<ExternalImageResponse> deleteSuccess() {
-		String resultMessage = randomLatencyImageManager.deleteImage("");
+	public ResponseEntity<ExternalImageResponse> deleteSuccess(@RequestBody ImageRequest request) {
+		String resultMessage = randomLatencyImageManager.deleteImage(request.key());
 		return ResponseEntity.ok(new ExternalImageResponse(HttpStatus.OK.value(), resultMessage, null));
 	}
 
 	@GetMapping
-	public ResponseEntity<ExternalImageResponse> getSuccess() {
-		String imageDataResult = randomLatencyImageManager.getImage("");
+	public ResponseEntity<ExternalImageResponse> retrieveImage(@RequestBody ImageRequest request) {
+		String imageDataResult = randomLatencyImageManager.getImage(request.key());
 		return ResponseEntity.ok(new ExternalImageResponse(
 			HttpStatus.OK.value(), "retrieve complete", imageDataResult)
 		);

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageResponse.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageResponse.java
@@ -1,4 +1,4 @@
-package univ.earthbreaker.namu.server.external.api;
+package univ.earthbreaker.namu.server.external.api.image;
 
 public record ExternalImageResponse(int code, String message, Object data) {
 }

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageServerExceptionHandler.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageServerExceptionHandler.java
@@ -1,4 +1,4 @@
-package univ.earthbreaker.namu.server.external.api;
+package univ.earthbreaker.namu.server.external.api.image;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import univ.earthbreaker.namu.server.external.exception.ExternalBadRequestException;
 import univ.earthbreaker.namu.server.external.exception.ExternalImageServerException;
 
-@RestControllerAdvice(basePackages = "univ.earthbreaker.namu.external.server")
+@RestControllerAdvice(basePackages = "univ.earthbreaker.namu.server.external")
 public class ExternalImageServerExceptionHandler {
 
 	@ExceptionHandler(ExternalBadRequestException.class)

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageStorage.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ExternalImageStorage.java
@@ -1,14 +1,14 @@
-package univ.earthbreaker.namu.server.external.api;
+package univ.earthbreaker.namu.server.external.api.image;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import univ.earthbreaker.namu.server.external.exception.ExternalBadRequestException;
 import univ.earthbreaker.namu.server.external.exception.ExternalImageServerException;
 
 public class ExternalImageStorage {
 
-	private final Map<String, String> storage = new HashMap<>();
+	private final Map<String, String> storage = new ConcurrentHashMap<>();
 
 	public String upload(String imageKey, String imageData) {
 		if (storage.get(imageKey) != null) { // 중복 검사

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ImageRequest.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ImageRequest.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.server.external.api.image;
+
+public record ImageRequest(
+	String bucketName,
+	String key
+) {
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ImageUploadRequest.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ImageUploadRequest.java
@@ -1,0 +1,11 @@
+package univ.earthbreaker.namu.server.external.api.image;
+
+import java.io.InputStream;
+
+public record ImageUploadRequest(
+	String bucketName,
+	String key,
+	InputStream inputStream,
+	ObjectMetaData objectMetaData
+) {
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ObjectMetaData.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/ObjectMetaData.java
@@ -1,0 +1,35 @@
+package univ.earthbreaker.namu.server.external.api.image;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import univ.earthbreaker.namu.server.external.Headers;
+
+public class ObjectMetaData {
+
+	private final Map<String, Object> metadata = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+	public ObjectMetaData() {
+	}
+
+	public void setContentType(String contentType) {
+		metadata.put(Headers.CONTENT_TYPE, contentType);
+	}
+
+	public void setContentLength(long contentLength) {
+		metadata.put(Headers.CONTENT_LENGTH, contentLength);
+	}
+
+	public String getContentType() {
+		return (String)metadata.get(Headers.CONTENT_TYPE);
+	}
+
+	public long getContentLength() {
+		Long contentLength = (Long)metadata.get(Headers.CONTENT_LENGTH);
+
+		if (contentLength == null) {
+			return 0;
+		}
+		return contentLength.longValue();
+	}
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/RandomLatencyImageManager.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/image/RandomLatencyImageManager.java
@@ -1,4 +1,4 @@
-package univ.earthbreaker.namu.server.external.api;
+package univ.earthbreaker.namu.server.external.api.image;
 
 import java.util.Random;
 
@@ -34,7 +34,7 @@ public class RandomLatencyImageManager {
 	 * @param imageData 이미지 파일 데이터
 	 * @return 업로드 결과 메시지
 	 */
-	public String uploadImage(String imageKey, String imageData) {
+	public String uploadImage(String imageKey, String imageData) throws ExternalImageServerException {
 		int delay = getDelay();
 		delaySimulation(delay);
 		invokeException();
@@ -47,7 +47,7 @@ public class RandomLatencyImageManager {
 	 * @param imageKey 이미지 키
 	 * @return 삭제 결과 메시지
 	 */
-	public String deleteImage(String imageKey) {
+	public String deleteImage(String imageKey) throws ExternalImageServerException {
 		int delay = getDelay();
 		delaySimulation(delay);
 		invokeException();

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointApiServer.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointApiServer.java
@@ -1,0 +1,47 @@
+package univ.earthbreaker.namu.server.external.api.point;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/external/point")
+public class ExternalPointApiServer {
+
+	private final ZzaptarbucksRandomLatencyPointManager pointManager;
+	private final IdempotencyStorage idempotencyStorage;
+
+	public ExternalPointApiServer(
+		ZzaptarbucksRandomLatencyPointManager pointManager,
+		IdempotencyStorage idempotencyStorage
+	) {
+		this.pointManager = pointManager;
+		this.idempotencyStorage = idempotencyStorage;
+	}
+
+	@PostMapping("/issue")
+	public ResponseEntity<ExternalPointResponse> issuePoint(
+		@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+		@RequestBody PointIssueRequest request
+	) {
+		if (idempotencyKey != null) {
+			ExternalPointResponse cached = idempotencyStorage.get(idempotencyKey);
+			if (cached != null) {
+				return ResponseEntity.ok(cached);
+			}
+		}
+
+		Long point = pointManager.issue();
+		ExternalPointResponse response = new ExternalPointResponse(HttpStatus.OK.value(), "success", point);
+
+		if (idempotencyKey != null) {
+			idempotencyStorage.put(idempotencyKey, response);
+		}
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointResponse.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointResponse.java
@@ -1,0 +1,4 @@
+package univ.earthbreaker.namu.server.external.api.point;
+
+public record ExternalPointResponse(int code, String message, Long point) {
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointServerExceptionHandler.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ExternalPointServerExceptionHandler.java
@@ -1,0 +1,27 @@
+package univ.earthbreaker.namu.server.external.api.point;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import univ.earthbreaker.namu.server.external.exception.ExternalBadRequestException;
+import univ.earthbreaker.namu.server.external.exception.ExternalImageServerException;
+
+@RestControllerAdvice(basePackages = "univ.earthbreaker.namu.server.external")
+public class ExternalPointServerExceptionHandler {
+
+	@ExceptionHandler(ExternalBadRequestException.class)
+	public ResponseEntity<ExternalPointResponse> handle400Exception(ExternalBadRequestException exception) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(new ExternalPointResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage(), null));
+	}
+
+	@ExceptionHandler(ExternalImageServerException.class)
+	public ResponseEntity<ExternalPointResponse> handle500Exception(ExternalImageServerException exception) {
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ExternalPointResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.getMessage(), null));
+	}
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/IdempotencyStorage.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/IdempotencyStorage.java
@@ -1,0 +1,20 @@
+package univ.earthbreaker.namu.server.external.api.point;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdempotencyStorage {
+
+	private final Map<String, ExternalPointResponse> storage = new ConcurrentHashMap<>();
+
+	public ExternalPointResponse get(String key) {
+		return storage.get(key);
+	}
+
+	public void put(String key, ExternalPointResponse value) {
+		storage.put(key, value);
+	}
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/PointIssueRequest.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/PointIssueRequest.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.server.external.api.point;
+
+public record PointIssueRequest(
+	long userId,
+	long missionId,
+	long timestamp
+) {
+}

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ZzaptarbucksRandomLatencyPointManager.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/api/point/ZzaptarbucksRandomLatencyPointManager.java
@@ -1,14 +1,16 @@
-package univ.earthbreaker.namu.clients.point;
+package univ.earthbreaker.namu.server.external.api.point;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.stereotype.Component;
 
-@Component
-public class ZzaptarbucksRandomLatencyPointManager implements PointManager {
+import univ.earthbreaker.namu.server.external.exception.ExternalPointServerException;
 
-	private static final AtomicLong POINT = new AtomicLong(10_000_000) ;
+@Component
+public class ZzaptarbucksRandomLatencyPointManager {
+
+	private static final AtomicLong POINT = new AtomicLong(100_000_000) ;
 	private static final Random RANDOM = new Random();
 
 	private static final long FIXED_REWARD_POINT = 10;
@@ -17,24 +19,23 @@ public class ZzaptarbucksRandomLatencyPointManager implements PointManager {
 	private static final double EXCEPTION_PROBABILITY = 0.01; // 예외 발생 확률 (1%)
 
 	/**
-	 * 총 1천만 포인트에 대해서, 사용자 별로 10포인트 씩 제공
-	 * @throws IllegalStateException : 준비되니 1천만 포인트가 모두 사라진 경우 예외 발생
+	 * 총 1억 포인트에 대해서, 사용자 별로 10포인트 씩 제공
+	 * @throws IllegalStateException : 준비된 1억 포인트가 모두 사라진 경우 예외 발생
 	 * @return 10포인트
 	 */
-	@Override
 	public Long issue() {
 		int delay = getDelay();
 		delaySimulation(delay);
 		invokeException();
 
-		long current = POINT.get();
-		long next = current - FIXED_REWARD_POINT;
+		POINT.updateAndGet(current -> {
+			long next = current - FIXED_REWARD_POINT;
+			if (next < 0) {
+				throw new IllegalStateException("The point has been reached");
+			}
+			return next;
+		});
 
-		if (next < 0) {
-			throw new IllegalStateException("The point has been reached");
-		}
-
-		POINT.compareAndSet(current, next);
 		return FIXED_REWARD_POINT; // 지급한 포인트만 반환
 	}
 
@@ -53,7 +54,7 @@ public class ZzaptarbucksRandomLatencyPointManager implements PointManager {
 		try {
 			Thread.sleep(delay);
 		} catch (InterruptedException e) {
-			throw new PointServerException(e.getMessage());
+			throw new ExternalPointServerException(e.getMessage());
 		}
 	}
 
@@ -62,7 +63,7 @@ public class ZzaptarbucksRandomLatencyPointManager implements PointManager {
 	 */
 	private void invokeException() {
 		if (RANDOM.nextDouble() < EXCEPTION_PROBABILITY) {
-			throw new PointServerException("Read Timeout Exception");
+			throw new ExternalPointServerException("Read Timeout Exception");
 		}
 	}
 }

--- a/server/external/src/main/java/univ/earthbreaker/namu/server/external/exception/ExternalPointServerException.java
+++ b/server/external/src/main/java/univ/earthbreaker/namu/server/external/exception/ExternalPointServerException.java
@@ -1,0 +1,7 @@
+package univ.earthbreaker.namu.server.external.exception;
+
+public class ExternalPointServerException extends RuntimeException {
+	public ExternalPointServerException(String message) {
+		super(message);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ include 'core:domain', 'core:storage'
 
 include 'services:auth', 'services:notification'
 
-include 'clients:oauth', 'clients:aws', 'clients:image'
+include 'clients:oauth', 'clients:aws', 'clients:image', 'clients:point'
 
 include 'event'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 
 rootProject.name = 'namu'
 
-include 'app:api', 'app:batch'
+include 'app:api', 'app:batch', 'app:kafka'
 
 include 'core:domain', 'core:storage'
 


### PR DESCRIPTION
### 문제
비즈니스 로직 처리 과정에서 외부 API 통신(네트워크 장애, 타임아웃 등)이 발생
이로 인해 HTTP 요청 스레드가 블록 → 전체 처리량 저하 발생

### 해결
실패한 작업을 바로 처리하려 하지 않고, 작업 상태를 marking 후 영속화
문제 발생 시 예외를 catch
이후 해당 작업을 Kafka Producer → Consumer를 통해 비동기 처리

### 효과
사용자 HTTP 요청은 빠르게 반환 가능
네트워크 이슈로 실패한 작업은 비동기 컨슈머가 재처리
장애가 발생한 시점 이후의 비즈니스 로직도 순차적으로 이어서 수행 가능


## 주요 변경 사항

### 1. Kafka Consumer 추가 (MissionRetryConsumer)

- 토픽: `earthbreaker.namu.mission-retry`

- 메시지(RetryMessage)의 retryStep 단계에 따라 작업을 재처리

    - IMAGE_UPLOAD 단계 실패 시 → 이미지 업로드 재시도 후 포인트 발급, 미션 성공 처리

    - POINT_ISSUE 단계 실패 시 → 포인트 발급 재시도 후 미션 성공 처리

### 2. Retry 처리 로직

- `handleImageUploadRetry`

    - 이미지가 존재하지 않으면 재업로드 시도

    - 실패 시 메시지를 **다음 시도 단계(IMAGE_UPLOAD)**로 재전송

- `handlePointRetry`

    - 포인트 지급 시도

    - 실패 시 메시지를 다음 시도 단계(POINT_ISSUE) 로 재전송

- 재시도 횟수(MAX_RETRY_ATTEMPTS) 초과 시 더 이상 재전송하지 않음

### 3. 성공 처리

- 이미지 업로드와 포인트 발급이 성공적으로 완료되면 `memberMissionCertifyService.successMission(...)` 호출을 통해 미션 성공 처리 및 DB insert 로직 처리


## 추가 고려 사항

> 재시도 횟수(MAX_RETRY_ATTEMPTS) 초과 시 더 이상 재전송하지 않음

**재시도 횟수 초과 시에도 실패한 레코드에 대한 처리** 고려 필요