### PR TITLE
[외부 이미지 서버로 교체 시 발생하는 문제 해결 2] HTTP 스레드 점유 문제 해결 - kafka producer 

### DIFF
--- a/app/api/build.gradle
+++ b/app/api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation project(":app:batch")
 
     implementation project(":core:domain")

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
@@ -1,0 +1,48 @@
+package univ.earthbreaker.namu.app.api.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+	private final KafkaProperties kafkaProperties;
+
+	public KafkaProducerConfig(KafkaProperties kafkaProperties) {
+		this.kafkaProperties = kafkaProperties;
+	}
+
+	@Bean
+	public ProducerFactory<String, RetryMessage> producerFactory() {
+		Map<String, Object> props = new HashMap<>(kafkaProperties.getProperties());
+		return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new JsonSerializer<>());
+	}
+
+	@Bean
+	public KafkaTemplate<String, RetryMessage> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+
+	@Bean
+	public KafkaAdmin.NewTopics topics() {
+		return new KafkaAdmin.NewTopics(
+			TopicBuilder.name("earthbreaker.namu.mission-retry")
+				.partitions(10)
+				.replicas(3)
+				.build()
+		);
+	}
+}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,12 +38,46 @@ public class KafkaProducerConfig {
 	}
 
 	@Bean
-	public KafkaAdmin.NewTopics topics() {
+	public KafkaAdmin.NewTopics topics(
+		@Value("${kafka.topics.mission-retry.name}") String retryTopicName,
+		@Value("${kafka.topics.mission-retry.partitions}") int retryPartitions,
+		@Value("${kafka.topics.mission-retry.replicas}") int retryReplicas
+	) {
 		return new KafkaAdmin.NewTopics(
-			TopicBuilder.name("earthbreaker.namu.mission-retry")
-				.partitions(10)
-				.replicas(3)
+			TopicBuilder.name(retryTopicName)
+				.partitions(retryPartitions)
+				.replicas(retryReplicas)
 				.build()
 		);
 	}
+
+	public record RetryMessage(
+		long memberNo,
+		long missionNo,
+		String imagePathKey,
+		String postContents,
+		RetryStep retryStep,
+		int attempt
+	) {
+		public static RetryMessage create(
+			long memberNo,
+			long missionNo,
+			String imagePathKey,
+			String postContents,
+			RetryStep retryStep
+		) {
+			return new RetryMessage(memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
+		}
+
+		public String getKey() {
+			return memberNo + ":" + missionNo + ":" + imagePathKey;
+		}
+	}
+
+	public enum RetryStep {
+		IMAGE_UPLOAD,
+		POINT_ISSUE,
+		;
+	}
+
 }

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -55,20 +55,18 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		CompletableFuture.runAsync(() -> {
-			String imagePathKey = uploadImage(missionImageFile);
-			if (imagePathKey == null) {
-				return;
-			}
-			Long point = getReward();
-			if (point == null) {
-				return;
-			}
-			missionCertifyService.successMission(
-				new MissionCompleteCommand(memberNo, missionNo),
-				new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
-			);
-		}, executor);
+		String imagePathKey = uploadImage(missionImageFile);
+		if (imagePathKey == null) {
+			return ResponseEntity.accepted().build();
+		}
+		Long point = getReward();
+		if (point == null) {
+			return ResponseEntity.accepted().build();
+		}
+		missionCertifyService.successMission(
+			new MissionCompleteCommand(memberNo, missionNo),
+			new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
+		);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,17 +28,23 @@ import univ.earthbreaker.namu.external.image.ImageUploadCommand;
 public class MissionCertifyController {
 
 	private final ImageManager imageManager;
+	private final PointManager pointManager;
 	private final MemberMissionCertifyService missionCertifyService;
 	private final Executor executor;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
+		PointManager pointManager,
 		MemberMissionCertifyService missionCertifyService,
-		Executor threadPoolExecutor
+		Executor threadPoolExecutor,
+		KafkaTemplate<String, RetryMessage> kafkaTemplate
 	) {
 		this.imageManager = imageManager;
+		this.pointManager = pointManager;
 		this.missionCertifyService = missionCertifyService;
 		this.executor = threadPoolExecutor;
+		this.kafkaTemplate = kafkaTemplate;
 	}
 
 	@AuthMapping
@@ -48,19 +55,38 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		CompletableFuture.supplyAsync(
-				() -> imageManager.upload(new ImageUploadCommand()),
-				executor
-			)
-			.exceptionally(ex -> null)
-			.thenAccept(result -> {
-				if (result != null) {
-					missionCertifyService.successMission(
-						new MissionCompleteCommand(memberNo, missionNo),
-						new CertifiedMissionPostCommand(memberNo, content, result)
-					);
-				}
-			});
+		String imagePathKey = uploadImage(missionImageFile);
+		if (imagePathKey == null) {
+			return ResponseEntity.accepted().build();
+		}
+		Long point = getReward();
+		if (point == null) {
+			return ResponseEntity.accepted().build();
+		}
+		missionCertifyService.successMission(
+			new MissionCompleteCommand(memberNo, missionNo),
+			new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
+		);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	private String uploadImage(MultipartFile missionImageFile) {
+		try {
+			return imageManager.upload(new ImageUploadCommand(missionImageFile));
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.IMAGE_UPLOAD);
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			return null;
+		}
+	}
+
+	private Long getReward() {
+		try {
+			return pointManager.reward();
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.POINT_ISSUE);
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			return null;
+		}
 	}
 }

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -1,9 +1,10 @@
 package univ.earthbreaker.namu.app.api.mission;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryMessage;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryStep;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,21 +31,21 @@ public class MissionCertifyController {
 	private final ImageManager imageManager;
 	private final PointManager pointManager;
 	private final MemberMissionCertifyService missionCertifyService;
-	private final Executor executor;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
+	private final String missionRetryTopic;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
 		PointManager pointManager,
 		MemberMissionCertifyService missionCertifyService,
-		Executor threadPoolExecutor,
-		KafkaTemplate<String, RetryMessage> kafkaTemplate
+		KafkaTemplate<String, RetryMessage> kafkaTemplate,
+		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
 		this.missionCertifyService = missionCertifyService;
-		this.executor = threadPoolExecutor;
 		this.kafkaTemplate = kafkaTemplate;
+		this.missionRetryTopic = missionRetryTopic;
 	}
 
 	@AuthMapping
@@ -59,7 +60,7 @@ public class MissionCertifyController {
 		if (imagePathKey == null) {
 			return ResponseEntity.accepted().build();
 		}
-		Long point = getReward();
+		Long point = getReward(memberNo, missionNo, imagePathKey, content);
 		if (point == null) {
 			return ResponseEntity.accepted().build();
 		}
@@ -70,22 +71,22 @@ public class MissionCertifyController {
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
-	private String uploadImage(MultipartFile missionImageFile) {
+	private String uploadImage(Long memberNo, Long missionNo, String content, MultipartFile missionImageFile) {
 		try {
 			return imageManager.upload(new ImageUploadCommand(missionImageFile));
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.IMAGE_UPLOAD);
-			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
+			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
 	}
 
-	private Long getReward() {
+	private Long getReward(Long memberNo, Long missionNo, String imagePathKey, String content) {
 		try {
 			return pointManager.reward();
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.POINT_ISSUE);
-			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
+			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
 	}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,17 +28,23 @@ import univ.earthbreaker.namu.external.image.ImageUploadCommand;
 public class MissionCertifyController {
 
 	private final ImageManager imageManager;
+	private final PointManager pointManager;
 	private final MemberMissionCertifyService missionCertifyService;
 	private final Executor executor;
+	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
+		PointManager pointManager,
 		MemberMissionCertifyService missionCertifyService,
-		Executor threadPoolExecutor
+		Executor threadPoolExecutor,
+		KafkaTemplate<String, RetryMessage> kafkaTemplate
 	) {
 		this.imageManager = imageManager;
+		this.pointManager = pointManager;
 		this.missionCertifyService = missionCertifyService;
 		this.executor = threadPoolExecutor;
+		this.kafkaTemplate = kafkaTemplate;
 	}
 
 	@AuthMapping
@@ -48,19 +55,40 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		CompletableFuture.supplyAsync(
-				() -> imageManager.upload(new ImageUploadCommand()),
-				executor
-			)
-			.exceptionally(ex -> null)
-			.thenAccept(result -> {
-				if (result != null) {
-					missionCertifyService.successMission(
-						new MissionCompleteCommand(memberNo, missionNo),
-						new CertifiedMissionPostCommand(memberNo, content, result)
-					);
-				}
-			});
+		CompletableFuture.runAsync(() -> {
+			String imagePathKey = uploadImage(missionImageFile);
+			if (imagePathKey == null) {
+				return;
+			}
+			Long point = getReward();
+			if (point == null) {
+				return;
+			}
+			missionCertifyService.successMission(
+				new MissionCompleteCommand(memberNo, missionNo),
+				new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
+			);
+		}, executor);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	private String uploadImage(MultipartFile missionImageFile) {
+		try {
+			return imageManager.upload(new ImageUploadCommand(missionImageFile));
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.IMAGE_UPLOAD);
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			return null;
+		}
+	}
+
+	private Long getReward() {
+		try {
+			return pointManager.reward();
+		} catch (Exception e) {
+			RetryMessage retryMessage = RetryMessage.of(memberNo, missionNo, content, RetryStep.POINT_ISSUE);
+			kafkaTemplate.send("earthbreaker.namu.mission-retry", retryMessage.getKey(), retryMessage);
+			return null;
+		}
 	}
 }

--- a/app/api/src/main/resources/application.yml
+++ b/app/api/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       - auth.yml
 #      - clients-aws.yml
       - clients-oauth.yml
+      - classpath:kafka/kafka-producer.yml
       - notification.yml
       - storage-core.yml
       - logging.yml

--- a/app/api/src/main/resources/kafka/kafka-producer.yml
+++ b/app/api/src/main/resources/kafka/kafka-producer.yml
@@ -1,0 +1,23 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      acks: all
+      retries: 10
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+
+---
+spring.config.activate.on-profile: local
+
+---
+spring.config.activate.on-profile: local-dev
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: staging
+
+---
+spring.config.activate.on-profile: live

--- a/app/api/src/main/resources/kafka/kafka-producer.yml
+++ b/app/api/src/main/resources/kafka/kafka-producer.yml
@@ -2,10 +2,13 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     producer:
-      acks: all
-      retries: 10
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        acks: all
+        enable.idempotence: true
+        retries: 2147483647
+        max.in.flight.requests.per.connection: 1
 
 ---
 spring.config.activate.on-profile: local

--- a/app/api/src/main/resources/kafka/kafka-producer.yml
+++ b/app/api/src/main/resources/kafka/kafka-producer.yml
@@ -10,6 +10,13 @@ spring:
         retries: 2147483647
         max.in.flight.requests.per.connection: 1
 
+kafka:
+  topics:
+    mission-retry:
+      name: earthbreaker.namu.mission-retry
+      replicas: 3
+      partitions: 12
+
 ---
 spring.config.activate.on-profile: local
 


### PR DESCRIPTION
### 문제
비즈니스 로직 처리 과정에서 외부 API 통신(네트워크 장애, 타임아웃 등)이 발생
이로 인해 HTTP 요청 스레드가 블록 → 전체 처리량 저하 발생

### 해결
실패한 작업을 바로 처리하려 하지 않고, 작업 상태를 marking 후 영속화
문제 발생 시 예외를 catch
이후 해당 작업을 Kafka Producer → Consumer를 통해 비동기 처리

### 효과
사용자 HTTP 요청은 빠르게 반환 가능
네트워크 이슈로 실패한 작업은 비동기 컨슈머가 재처리
장애가 발생한 시점 이후의 비즈니스 로직도 순차적으로 이어서 수행 가능


## 주요 변경 사항

위에 나열한 **해결** 방법 대로, 실패한 작업을 바로 처리하지 않고, 문제 발생 시 예외를 catch 하여 카프카 이벤트 발행.

- image upload 요청 중 예외 발생 시 retry topic 으로 레코드 발행
- point reward 요청 중 예외 발생 시 retry topic 으로 레코드 발행

### 아직 부족한 사항

- Kafka 관련 설정 및 producer-consumer 에서 공통적으로 사용되는 RetryMessage DTO(메시지 값 레코드) 에 대한 처리.
- HTTP Polling 미적용