### PR TITLE
사용자의 비즈니스 로직 추적을 위한 HTTP Polling API 개발

### DIFF
--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/config/KafkaProducerConfig.java
@@ -52,6 +52,7 @@ public class KafkaProducerConfig {
 	}
 
 	public record RetryMessage(
+		String requestId,
 		long memberNo,
 		long missionNo,
 		String imagePathKey,
@@ -60,17 +61,18 @@ public class KafkaProducerConfig {
 		int attempt
 	) {
 		public static RetryMessage create(
+			String requestId,
 			long memberNo,
 			long missionNo,
 			String imagePathKey,
 			String postContents,
 			RetryStep retryStep
 		) {
-			return new RetryMessage(memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
+			return new RetryMessage(requestId, memberNo, missionNo, imagePathKey, postContents, retryStep, 1);
 		}
 
 		public String getKey() {
-			return memberNo + ":" + missionNo + ":" + imagePathKey;
+			return requestId;
 		}
 	}
 

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertificationStatusResponse.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertificationStatusResponse.java
@@ -1,0 +1,19 @@
+package univ.earthbreaker.namu.app.api.mission;
+
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyStatus;
+
+public record MissionCertificationStatusResponse(
+	String requestId,
+	long memberNo,
+	long missionNo,
+	String process
+) {
+	static MissionCertificationStatusResponse from(MissionCertifyStatus status) {
+		return new MissionCertificationStatusResponse(
+			status.getRequestId(),
+			status.getMemberNo(),
+			status.getMissionNo(),
+			status.getProcess().name()
+		);
+	}
+}

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -91,4 +91,10 @@ public class MissionCertifyController {
 			return null;
 		}
 	}
+
+	@GetMapping("/certification/status/{requestId}")
+	public ResponseEntity<MissionCertificationStatusResponse> pollCertifyProcess(@PathVariable String requestId) {
+		MissionCertifyStatus status = missionCertifyTrackingService.retrieve(requestId);
+		return ResponseEntity.ok(MissionCertificationStatusResponse.from(status));
+	}
 }

--- a/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
+++ b/app/api/src/main/java/univ/earthbreaker/namu/app/api/mission/MissionCertifyController.java
@@ -1,7 +1,8 @@
 package univ.earthbreaker.namu.app.api.mission;
 
-import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryMessage;
-import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.RetryStep;
+import static univ.earthbreaker.namu.app.api.config.KafkaProducerConfig.*;
+
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +20,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 import univ.earthbreaker.namu.app.support.AuthMapping;
 import univ.earthbreaker.namu.app.support.LoginMember;
+import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyStatus;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 import univ.earthbreaker.namu.external.image.ImageManager;
-import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.external.image.ImageUploadCommand;
 
 @RestController
@@ -31,6 +36,7 @@ public class MissionCertifyController {
 
 	private final ImageManager imageManager;
 	private final PointManager pointManager;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final MemberMissionCertifyService missionCertifyService;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
@@ -38,12 +44,14 @@ public class MissionCertifyController {
 	public MissionCertifyController(
 		@Qualifier("externalImageManager") ImageManager imageManager,
 		PointManager pointManager,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		MemberMissionCertifyService missionCertifyService,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.missionCertifyService = missionCertifyService;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
@@ -57,36 +65,50 @@ public class MissionCertifyController {
 		@RequestPart(value = "content") String content,
 		@RequestPart(value = "imageFile") MultipartFile missionImageFile
 	) {
-		String imagePathKey = uploadImage(memberNo, missionNo, content, missionImageFile);
+		String requestId = UUID.randomUUID().toString();
+		missionCertifyTrackingService.register(requestId, memberNo, missionNo);
+
+		String imagePathKey = uploadImage(requestId, memberNo, missionNo, content, missionImageFile);
 		if (imagePathKey == null) {
-			return ResponseEntity.accepted().build();
+			return ResponseEntity.accepted().body(requestId);
 		}
-		Long point = getReward(memberNo, missionNo, imagePathKey, content);
+		Long point = getReward(requestId, memberNo, missionNo, imagePathKey, content);
 		if (point == null) {
-			return ResponseEntity.accepted().build();
+			return ResponseEntity.accepted().body(requestId);
 		}
+
 		missionCertifyService.successMission(
 			new MissionCompleteCommand(memberNo, missionNo),
 			new CertifiedMissionPostCommand(memberNo, content, imagePathKey, point)
 		);
+		missionCertifyTrackingService.update(requestId, MissionCertifyProcess.COMPLETED);
+
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
-	private String uploadImage(Long memberNo, Long missionNo, String content, MultipartFile missionImageFile) {
+	private String uploadImage(
+		String requestId,
+		Long memberNo,
+		Long missionNo,
+		String content,
+		MultipartFile missionImageFile
+	) {
 		try {
 			return imageManager.upload(new ImageUploadCommand());
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
+			RetryMessage retryMessage
+				= RetryMessage.create(requestId, memberNo, missionNo, null, content, RetryStep.IMAGE_UPLOAD);
 			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}
 	}
 
-	private Long getReward(Long memberNo, Long missionNo, String imagePathKey, String content) {
+	private Long getReward(String requestId, Long memberNo, Long missionNo, String imagePathKey, String content) {
 		try {
 			return pointManager.issue();
 		} catch (Exception e) {
-			RetryMessage retryMessage = RetryMessage.create(memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
+			RetryMessage retryMessage
+				= RetryMessage.create(requestId, memberNo, missionNo, imagePathKey, content, RetryStep.POINT_ISSUE);
 			kafkaTemplate.send(missionRetryTopic, retryMessage.getKey(), retryMessage);
 			return null;
 		}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/ImageUploadRetryService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 import univ.earthbreaker.namu.external.image.ImageManager;
 import univ.earthbreaker.namu.external.image.ImageUploadCommand;
@@ -21,6 +23,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 	private final ImageManager imageManager;
 	private final PointManager pointManager;
 	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
 
@@ -28,12 +31,14 @@ public class ImageUploadRetryService implements MissionRetryer {
 		ImageManager imageManager,
 		PointManager pointManager,
 		MemberMissionCertifyService memberMissionCertifyService,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.imageManager = imageManager;
 		this.pointManager = pointManager;
 		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
 	}
@@ -58,6 +63,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
 			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
 		);
+		missionCertifyTrackingService.update(key, MissionCertifyProcess.COMPLETED);
 	}
 
 	private boolean handleImageUploadRetry(String key, RetryMessage message) {
@@ -85,6 +91,7 @@ public class ImageUploadRetryService implements MissionRetryer {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
 			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
+			missionCertifyTrackingService.update(key, MissionCertifyProcess.FAILED);
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}
 	}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/PointIssueRetryService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import univ.earthbreaker.namu.clients.point.PointManager;
 import univ.earthbreaker.namu.core.domain.mission.CertifiedMissionPostCommand;
 import univ.earthbreaker.namu.core.domain.mission.MemberMissionCertifyService;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyProcess;
+import univ.earthbreaker.namu.core.domain.mission.MissionCertifyTrackingService;
 import univ.earthbreaker.namu.core.domain.mission.MissionCompleteCommand;
 
 @Service
@@ -17,17 +19,20 @@ public class PointIssueRetryService implements MissionRetryer {
 	private static final Logger log = LoggerFactory.getLogger(PointIssueRetryService.class);
 
 	private final MemberMissionCertifyService memberMissionCertifyService;
+	private final MissionCertifyTrackingService missionCertifyTrackingService;
 	private final PointManager pointManager;
 	private final KafkaTemplate<String, RetryMessage> kafkaTemplate;
 	private final String missionRetryTopic;
 
 	public PointIssueRetryService(
 		MemberMissionCertifyService memberMissionCertifyService,
+		MissionCertifyTrackingService missionCertifyTrackingService,
 		PointManager pointManager,
 		KafkaTemplate<String, RetryMessage> kafkaTemplate,
 		@Value("${kafka.topics.mission-retry.name}") String missionRetryTopic
 	) {
 		this.memberMissionCertifyService = memberMissionCertifyService;
+		this.missionCertifyTrackingService = missionCertifyTrackingService;
 		this.pointManager = pointManager;
 		this.kafkaTemplate = kafkaTemplate;
 		this.missionRetryTopic = missionRetryTopic;
@@ -49,6 +54,7 @@ public class PointIssueRetryService implements MissionRetryer {
 			new MissionCompleteCommand(message.memberNo(), message.missionNo()),
 			new CertifiedMissionPostCommand(message.memberNo(), message.postContents(), message.imagePathKey(), point)
 		);
+		missionCertifyTrackingService.update(key, MissionCertifyProcess.COMPLETED);
 	}
 
 	private Long handlePointRetry(String key, RetryMessage message) {
@@ -64,6 +70,7 @@ public class PointIssueRetryService implements MissionRetryer {
 		if (RetryMessage.MAX_RETRY_ATTEMPTS >= message.attempt()) {
 			kafkaTemplate.send(missionRetryTopic, key, message);
 		} else {
+			missionCertifyTrackingService.update(key, MissionCertifyProcess.FAILED);
 			log.error("Retry failed for key: {}, record message : {}, exception : {}", key, message, e);
 		}
 	}

--- a/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
+++ b/app/kafka/src/main/java/univ/earthbreaker/namu/app/kafka/consumer/RetryMessage.java
@@ -1,6 +1,7 @@
 package univ.earthbreaker.namu.app.kafka.consumer;
 
 public record RetryMessage(
+	String requestId,
 	long memberNo,
 	long missionNo,
 	String imagePathKey,
@@ -12,6 +13,7 @@ public record RetryMessage(
 
 	public RetryMessage toNext(RetryStep retryStep) {
 		return new RetryMessage(
+			requestId,
 			memberNo,
 			missionNo,
 			imagePathKey,

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyProcess.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyProcess.java
@@ -1,0 +1,8 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+public enum MissionCertifyProcess {
+	PENDING,
+	COMPLETED,
+	FAILED,
+	;
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyStatus.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyStatus.java
@@ -1,0 +1,32 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+public class MissionCertifyStatus {
+
+	private final String requestId;
+	private final long memberNo;
+	private final long missionNo;
+	private final MissionCertifyProcess process;
+
+	public MissionCertifyStatus(String requestId, long memberNo, long missionNo, MissionCertifyProcess process) {
+		this.requestId = requestId;
+		this.memberNo = memberNo;
+		this.missionNo = missionNo;
+		this.process = process;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public long getMemberNo() {
+		return memberNo;
+	}
+
+	public long getMissionNo() {
+		return missionNo;
+	}
+
+	public MissionCertifyProcess getProcess() {
+		return process;
+	}
+}

--- a/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyTrackingService.java
+++ b/core/domain/src/main/java/univ/earthbreaker/namu/core/domain/mission/MissionCertifyTrackingService.java
@@ -1,0 +1,38 @@
+package univ.earthbreaker.namu.core.domain.mission;
+
+import org.springframework.stereotype.Service;
+
+import univ.earthbreaker.namu.core.support.tx.TransactionHandler;
+
+@Service
+public class MissionCertifyTrackingService {
+
+	private final MissionCertifyStatusRepository missionCertifyStatusRepository;
+	private final TransactionHandler transactionHandler;
+
+	public MissionCertifyTrackingService(
+		MissionCertifyStatusRepository missionCertifyStatusRepository,
+		TransactionHandler transactionHandler
+	) {
+		this.missionCertifyStatusRepository = missionCertifyStatusRepository;
+		this.transactionHandler = transactionHandler;
+	}
+
+	public void register(String requestId, long memberNo, long missionNo) {
+		transactionHandler.execute(() -> {
+			missionCertifyStatusRepository.register(requestId, memberNo, missionNo);
+			return null;
+		});
+	}
+
+	public void update(String requestId, MissionCertifyProcess process) {
+		transactionHandler.execute(() -> {
+			missionCertifyStatusRepository.update(requestId, process);
+			return null;
+		});
+	}
+
+	public MissionCertifyStatus retrieve(String requestId) {
+		return missionCertifyStatusRepository.retrieve(requestId);
+	}
+}


### PR DESCRIPTION
### 문제
비즈니스 로직 처리 과정에서 외부 API 통신(네트워크 장애, 타임아웃 등)이 발생
이로 인해 HTTP 요청 스레드가 블록 → 전체 처리량 저하 발생

### 해결
실패한 작업을 바로 처리하려 하지 않고, 작업 상태를 marking 후 영속화
문제 발생 시 예외를 catch
이후 해당 작업을 Kafka Producer → Consumer를 통해 비동기 처리

### 효과
사용자 HTTP 요청은 빠르게 반환 가능
네트워크 이슈로 실패한 작업은 비동기 컨슈머가 재처리
장애가 발생한 시점 이후의 비즈니스 로직도 순차적으로 이어서 수행 가능


## 주요 변경 사항

- 사용자가 오래 걸리는 비즈니스의 상태를 추적할 수 있도록 Polling API 제공
- 이를 위해 비즈니스의 상태 추적을 위한 `MissionCertifyStatus` 영속화 (db table 은 아직 미생성)
- 기존에 kafka producer/consumer 에서 공통으로 사용하던 `RetryMessage` 레코드의 메시지 키 값을 `userId:missionNo` 에서 **UUID 기반의 requestId** 로 변경

### 아직 부족한 사항

- DB 를 사용해 비즈니스의 상태를 영속화함으로써, `MissionCertifyController` 로직에서 발생하는 트랜잭션 / 원자성 보장 문제가 염려됨
    - successMission()에서 게시글 삽입 + 포인트 저장 같은 복수 작업의 원자성 보장 불명확
    - 외부 시스템(포인트 서버, 이미지 서버 등)과의 상호작용이 있으므로 부분 성공(일부 반영) 시 데이터 정합성 문제 발생
